### PR TITLE
Add scala-collection-compat to codebase

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,12 +21,11 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   else nextVersion + "-SNAPSHOT"
 }
 
-val scalacOpts = List(
-  "-unchecked",
-  "-deprecation",
-  "-feature",
-  "-language:higherKinds",
-  "-language:implicitConversions")
+val scalacOpts = List("-unchecked",
+                      "-deprecation",
+                      "-feature",
+                      "-language:higherKinds",
+                      "-language:implicitConversions")
 
 ThisBuild / Compile / scalacOptions := scalacOpts
 ThisBuild / Test / scalacOptions := scalacOpts

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,12 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   else nextVersion + "-SNAPSHOT"
 }
 
-val scalacOpts = List("-unchecked", "-deprecation", "-feature")
+val scalacOpts = List(
+  "-unchecked",
+  "-deprecation",
+  "-feature",
+  "-language:higherKinds",
+  "-language:implicitConversions")
 
 ThisBuild / Compile / scalacOptions := scalacOpts
 ThisBuild / Test / scalacOptions := scalacOpts
@@ -76,13 +81,14 @@ lazy val root = (project in file("."))
     doc / aggregate := false,
     doc := (sconfigJVM / Compile / doc).value,
     packageDoc / aggregate := false,
-    packageDoc := (sconfigJVM / Compile / packageDoc).value,
+    packageDoc := (sconfigJVM / Compile / packageDoc).value
   )
 
 lazy val sconfig = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .crossType(CrossType.Full)
   .jvmSettings(
     sharedJvmNativeSource,
+    sharedCollectSource,
     libraryDependencies += "io.crashbox"  %% "spray-json"     % "1.3.5-5" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11"    % Test,
     Compile / compile / javacOptions ++= Seq("-source",
@@ -111,16 +117,26 @@ lazy val sconfig = crossProject(JVMPlatform, NativePlatform, JSPlatform)
     crossScalaVersions := List(scala211),
     scalaVersion := scala211, // allows to compile if scalaVersion set not 2.11
     sharedJvmNativeSource,
+    sharedCollectSource,
     nativeLinkStubs := true,
   )
   .jsSettings(
     libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
+    sharedCollectSource,
   )
 
 lazy val sharedJvmNativeSource: Seq[Setting[_]] = Def.settings(
   Compile / unmanagedSourceDirectories +=
     (ThisBuild / baseDirectory).value
       / "sconfig" / "sharedjvmnative" / "src" / "main" / "scala"
+)
+// added collection compat - revisit when 2.11 and 2.12 are dropped
+lazy val sharedCollectSource: Seq[Setting[_]] = Def.settings(
+  unmanagedSourceDirectories in Compile += {
+    val sharedSourceDir = (baseDirectory in ThisBuild).value / "sconfig/shared/src/main"
+    if (scalaVersion.value.startsWith("2.13.")) sharedSourceDir / "scala-2.13"
+    else sharedSourceDir / "scala-2.11_2.12"
+  }
 )
 
 lazy val sconfigJVM = sconfig.jvm

--- a/sconfig/jvm/src/main/scala/org/ekrich/config/impl/ConfigBeanImpl.scala
+++ b/sconfig/jvm/src/main/scala/org/ekrich/config/impl/ConfigBeanImpl.scala
@@ -13,6 +13,7 @@ import java.{util => ju}
 import java.{lang => jl}
 import java.time.Duration
 import scala.reflect.ClassTag
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigObject
@@ -48,7 +49,6 @@ object ConfigBeanImpl {
     val configProps =
       new ju.HashMap[String, AbstractConfigValue]
     val originalNames = new ju.HashMap[String, String]
-    import scala.collection.JavaConverters._
     for (configProp <- config.root.entrySet.asScala) {
       val originalName = configProp.getKey
       val camelName    = ConfigImplUtil.toCamelCase(originalName)
@@ -84,7 +84,6 @@ object ConfigBeanImpl {
       // Try to throw all validation issues at once (this does not comprehensively
       // find every issue, but it should find common ones).
       val problems = new ju.ArrayList[ConfigException.ValidationProblem]
-      import scala.collection.JavaConverters._
       for (beanProp <- beanProps.asScala) {
         val setter: Method           = beanProp.getWriteMethod
         val parameterClass: Class[_] = setter.getParameterTypes()(0)
@@ -105,7 +104,6 @@ object ConfigBeanImpl {
         throw new ConfigException.ValidationFailed(problems)
       // Fill in the bean instance
       val bean = clazz.getConstructor().newInstance()
-      import scala.collection.JavaConverters._
       for (beanProp <- beanProps.asScala) {
         breakable {
           val setter         = beanProp.getWriteMethod
@@ -258,7 +256,6 @@ object ConfigBeanImpl {
       val beanList = new ju.ArrayList[AnyRef]
       val configList: ju.List[_ <: Config] =
         config.getConfigList(configPropName)
-      import scala.collection.JavaConverters._
       for (listMember <- configList.asScala) {
         beanList.add(
           createInternal(listMember, elementType.asInstanceOf[Class[T]]))

--- a/sconfig/jvm/src/test/scala/ApiExamples.scala
+++ b/sconfig/jvm/src/test/scala/ApiExamples.scala
@@ -4,7 +4,7 @@
 import org.junit.Assert._
 import org.junit._
 import org.ekrich.config._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import language.implicitConversions
 

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConcatenationTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConcatenationTest.scala
@@ -10,7 +10,7 @@ import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigResolveOptions
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigFactory
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ConcatenationTest extends TestUtils {
 

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfParserTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfParserTest.scala
@@ -9,7 +9,7 @@ import java.io.{File, StringReader}
 
 import org.ekrich.config._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.net.URL
 import java.util.Properties
 

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigBeanFactoryTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigBeanFactoryTest.scala
@@ -13,7 +13,7 @@ import beanconfig._
 import org.junit.Assert._
 import org.junit._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
 
 class ConfigBeanFactoryTest extends TestUtils {

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigDocumentTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigDocumentTest.scala
@@ -8,7 +8,7 @@ import org.ekrich.config.parser._
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ConfigDocumentTest extends TestUtils {
   private def configDocumentReplaceJsonTest(origText: String,

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigSubstitutionTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigSubstitutionTest.scala
@@ -10,7 +10,7 @@ import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigResolveOptions
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigFactory
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ConfigSubstitutionTest extends TestUtils {
 
@@ -167,7 +167,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def missingInArray(): Unit = {
-    import scala.collection.JavaConverters._
 
     val obj = parseObject("""
     a : [ ${?missing}, ${?also.missing} ]
@@ -180,7 +179,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def missingInObject(): Unit = {
-    import scala.collection.JavaConverters._
 
     val obj = parseObject(
       """
@@ -761,7 +759,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def complexResolve(): Unit = {
-    import scala.collection.JavaConverters._
 
     val resolved = resolveWithoutFallbacks(substComplexObject)
 
@@ -861,7 +858,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def fallbackToEnv(): Unit = {
-    import scala.collection.JavaConverters._
 
     val resolved = resolve(substEnvVarObject)
 
@@ -884,7 +880,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def noFallbackToEnvIfValuesAreNull(): Unit = {
-    import scala.collection.JavaConverters._
 
     // create a fallback object with all the env var names
     // set to null. we want to be sure this blocks
@@ -907,7 +902,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def fallbackToEnvWhenRelativized(): Unit = {
-    import scala.collection.JavaConverters._
 
     val values = new java.util.HashMap[String, AbstractConfigValue]()
 
@@ -971,7 +965,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def optionalVanishesFromArray(): Unit = {
-    import scala.collection.JavaConverters._
     val obj      = parseObject("""{ a : [ 1, 2, 3, ${?NOT_HERE} ] }""")
     val resolved = resolve(obj)
     assertEquals(Seq(1, 2, 3), resolved.getIntList("a").asScala)
@@ -979,7 +972,6 @@ class ConfigSubstitutionTest extends TestUtils {
 
   @Test
   def optionalUsedInArray(): Unit = {
-    import scala.collection.JavaConverters._
     val obj      = parseObject("""{ HERE: 4, a : [ 1, 2, 3, ${?HERE} ] }""")
     val resolved = resolve(obj)
     assertEquals(Seq(1, 2, 3, 4), resolved.getIntList("a").asScala)

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigTest.scala
@@ -10,7 +10,7 @@ import org.junit._
 import org.ekrich.config._
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigResolveOptions
 import java.util.concurrent.TimeUnit.{
   DAYS,

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigValueTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigValueTest.scala
@@ -8,7 +8,7 @@ import org.junit._
 import org.ekrich.config.ConfigValue
 import java.util.Collections
 import java.net.URL
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigObject
 import org.ekrich.config.ConfigList
 import org.ekrich.config.ConfigException
@@ -981,7 +981,6 @@ class ConfigValueTest extends TestUtils {
 
   @Test
   def configOriginsInSerialization(): Unit = {
-    import scala.collection.JavaConverters._
     val bases = Seq(
       SimpleConfigOrigin.newSimple("foo"),
       SimpleConfigOrigin.newFile("/tmp/blahblah"),

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/JsonTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/JsonTest.scala
@@ -10,6 +10,7 @@ import org.junit._
 
 import spray.json._
 
+import scala.jdk.CollectionConverters._
 import org.ekrich.config._
 
 class JsonTest extends TestUtils {
@@ -29,7 +30,6 @@ class JsonTest extends TestUtils {
   }
 
   private[this] def toJson(value: ConfigValue): JsValue = {
-    import scala.collection.JavaConverters._
 
     value match {
       case v: ConfigObject =>
@@ -56,7 +56,6 @@ class JsonTest extends TestUtils {
   }
 
   private[this] def fromJson(jsonValue: JsValue): AbstractConfigValue = {
-    import scala.collection.JavaConverters._
 
     jsonValue match {
       case JsObject(fields) =>

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PathTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PathTest.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import org.junit.Assert._
 import org.junit._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 
 class PathTest extends TestUtils {

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PropertiesTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PropertiesTest.scala
@@ -117,7 +117,6 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysWithGaps(): Unit = {
-    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.1", "0")
@@ -133,7 +132,6 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysWithNoise(): Unit = {
-    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.-1", "-1")
@@ -153,7 +151,6 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def noNumericKeysAsListFails(): Unit = {
-    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.bar", "0")
@@ -168,7 +165,6 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysAndMerge(): Unit = {
-    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.0", "0")

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PropertiesTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PropertiesTest.scala
@@ -6,6 +6,7 @@ package org.ekrich.config.impl
 import org.junit.Assert._
 import org.junit._
 import java.util.{Date, Properties}
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigParseOptions
 import org.ekrich.config.ConfigFactory
@@ -99,7 +100,6 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeys(): Unit = {
-    import scala.collection.JavaConverters._
 
     val props = new Properties()
     props.setProperty("a.0", "0")
@@ -117,7 +117,7 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysWithGaps(): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.1", "0")
@@ -133,7 +133,7 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysWithNoise(): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.-1", "-1")
@@ -153,7 +153,7 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def noNumericKeysAsListFails(): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.bar", "0")
@@ -168,7 +168,7 @@ class PropertiesTest extends TestUtils {
 
   @Test
   def makeListWithNumericKeysAndMerge(): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val props = new Properties()
     props.setProperty("a.0", "0")

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import org.junit.Assert._
 import org.junit._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config._
 import java.util.{Collections, TimeZone, TreeSet}
 import java.io.File

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
@@ -167,8 +167,7 @@ class PublicApiTest extends TestUtils {
   def fromJavaMap(): Unit = {
     val emptyMapValue = Collections.emptyMap[String, AbstractConfigValue]
     val aMapValue = Map("a" -> 1, "b" -> 2, "c" -> 3)
-      .mapValues(intValue(_): AbstractConfigValue)
-      .toMap
+    .transform((_, v) => (intValue(v): AbstractConfigValue))
       .asJava
     testFromValue(new SimpleConfigObject(fakeOrigin(), emptyMapValue),
                   Collections.emptyMap[String, Int])
@@ -242,8 +241,7 @@ class PublicApiTest extends TestUtils {
     val aMapValue = new SimpleConfigObject(
       fakeOrigin(),
       Map("a" -> 1, "b" -> 2, "c" -> 3)
-        .mapValues(intValue(_): AbstractConfigValue)
-        .toMap
+      .transform((_, v) => (intValue(v): AbstractConfigValue))
         .asJava)
 
     testFromValue(aMapValue, aMapValue)
@@ -290,8 +288,7 @@ class PublicApiTest extends TestUtils {
     // first the same tests as with fromMap, but use parseMap
     val emptyMapValue = Collections.emptyMap[String, AbstractConfigValue]
     val aMapValue = Map("a" -> 1, "b" -> 2, "c" -> 3)
-      .mapValues(intValue(_): AbstractConfigValue)
-      .toMap
+      .transform((_, v) => (intValue(v): AbstractConfigValue))
       .asJava
     testFromPathMap(new SimpleConfigObject(fakeOrigin(), emptyMapValue),
                     Collections.emptyMap[String, Object])

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
@@ -167,7 +167,7 @@ class PublicApiTest extends TestUtils {
   def fromJavaMap(): Unit = {
     val emptyMapValue = Collections.emptyMap[String, AbstractConfigValue]
     val aMapValue = Map("a" -> 1, "b" -> 2, "c" -> 3)
-    .transform((_, v) => (intValue(v): AbstractConfigValue))
+      .transform((_, v) => (intValue(v): AbstractConfigValue))
       .asJava
     testFromValue(new SimpleConfigObject(fakeOrigin(), emptyMapValue),
                   Collections.emptyMap[String, Int])
@@ -241,7 +241,7 @@ class PublicApiTest extends TestUtils {
     val aMapValue = new SimpleConfigObject(
       fakeOrigin(),
       Map("a" -> 1, "b" -> 2, "c" -> 3)
-      .transform((_, v) => (intValue(v): AbstractConfigValue))
+        .transform((_, v) => (intValue(v): AbstractConfigValue))
         .asJava)
 
     testFromValue(aMapValue, aMapValue)

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/TestUtils.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/TestUtils.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable
 import org.ekrich.config._
 import scala.reflect.ClassTag
 import scala.reflect.classTag
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import language.implicitConversions
 
 abstract trait TestUtils {
@@ -295,23 +295,20 @@ abstract trait TestUtils {
 
   // origin() is not part of value equality but is serialized, so
   // we check it separately
-  protected def checkEqualOrigins[T](a: T, b: T): Unit = {
-    import scala.collection.JavaConverters._
-    (a, b) match {
-      case (obj1: ConfigObject, obj2: ConfigObject) =>
-        assertEquals(obj1.origin, obj2.origin)
-        for (e <- obj1.entrySet().asScala) {
-          checkEqualOrigins(e.getValue(), obj2.get(e.getKey()))
-        }
-      case (list1: ConfigList, list2: ConfigList) =>
-        assertEquals(list1.origin, list2.origin)
-        for ((v1, v2) <- list1.asScala zip list2.asScala) {
-          checkEqualOrigins(v1, v2)
-        }
-      case (value1: ConfigValue, value2: ConfigValue) =>
-        assertEquals(value1.origin, value2.origin)
-      case _ =>
-    }
+  protected def checkEqualOrigins[T](a: T, b: T): Unit = (a, b) match {
+    case (obj1: ConfigObject, obj2: ConfigObject) =>
+      assertEquals(obj1.origin, obj2.origin)
+      for (e <- obj1.entrySet().asScala) {
+        checkEqualOrigins(e.getValue(), obj2.get(e.getKey()))
+      }
+    case (list1: ConfigList, list2: ConfigList) =>
+      assertEquals(list1.origin, list2.origin)
+      for ((v1, v2) <- list1.asScala zip list2.asScala) {
+        checkEqualOrigins(v1, v2)
+      }
+    case (value1: ConfigValue, value2: ConfigValue) =>
+      assertEquals(value1.origin, value2.origin)
+    case _ =>
   }
 
   def fakeOrigin() = {
@@ -649,7 +646,6 @@ abstract trait TestUtils {
 
   protected def substInString(ref: String,
                               optional: Boolean): ConfigConcatenation = {
-    import scala.collection.JavaConverters._
     val path = Path.newPath(ref)
     val pieces = List[AbstractConfigValue](stringValue("start<"),
                                            subst(ref, optional),
@@ -714,7 +710,6 @@ abstract trait TestUtils {
   }
 
   def tokenizeAsList(s: String) = {
-    import scala.collection.JavaConverters._
     tokenize(s).asScala.toList
   }
 
@@ -813,7 +808,6 @@ abstract trait TestUtils {
                                   val additions: Map[String, URL])
       extends ClassLoader(parent) {
     override def findResources(name: String) = {
-      import scala.collection.JavaConverters._
       val other = super.findResources(name).asScala
       additions
         .get(name)
@@ -861,7 +855,6 @@ abstract trait TestUtils {
         printIndented(indent, "- " + a.valueType)
         printIndented(indent, "+ " + b.valueType)
       } else if (a.valueType == ConfigValueType.OBJECT) {
-        import scala.collection.JavaConverters._
         printIndented(indent, "OBJECT")
         val aS = a.asInstanceOf[ConfigObject].asScala
         val bS = b.asInstanceOf[ConfigObject].asScala

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ValidationTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ValidationTest.scala
@@ -8,7 +8,7 @@ import org.junit._
 import org.ekrich.config.ConfigFactory
 import org.ekrich.config.ConfigParseOptions
 import org.ekrich.config.ConfigException
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Source
 
 class ValidationTest extends TestUtils {

--- a/sconfig/shared/src/main/scala-2.11/scala/collection/compat/package.scala
+++ b/sconfig/shared/src/main/scala-2.11/scala/collection/compat/package.scala
@@ -1,0 +1,15 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+package object compat extends compat.PackageShared

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/BuildFrom.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/BuildFrom.scala
@@ -1,0 +1,51 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.compat
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+
+/** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
+ * Implicit instances of `BuildFrom` are available for all collection types.
+ *
+ * @tparam From Type of source collection
+ * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+ * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+ */
+trait BuildFrom[-From, -A, +C] extends Any {
+  def fromSpecific(from: From)(it: IterableOnce[A]): C
+
+  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+    * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
+  def newBuilder(from: From): mutable.Builder[A, C]
+
+  @deprecated("Use newBuilder() instead of apply()", "2.13.0")
+  @`inline` def apply(from: From): mutable.Builder[A, C] = newBuilder(from)
+}
+
+object BuildFrom {
+
+  // Implicit instance derived from an implicit CanBuildFrom instance
+  implicit def fromCanBuildFrom[From, A, C](
+      implicit cbf: CanBuildFrom[From, A, C]): BuildFrom[From, A, C] =
+    new BuildFrom[From, A, C] {
+      def fromSpecific(from: From)(it: IterableOnce[A]): C = (cbf(from) ++= it).result()
+      def newBuilder(from: From): mutable.Builder[A, C]        = cbf(from)
+    }
+
+  // Implicit conversion derived from an implicit conversion to CanBuildFrom
+  implicit def fromCanBuildFromConversion[X, From, A, C](x: X)(
+      implicit toCanBuildFrom: X => CanBuildFrom[From, A, C]): BuildFrom[From, A, C] =
+    fromCanBuildFrom(toCanBuildFrom(x))
+
+}

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/BuildFrom.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/BuildFrom.scala
@@ -26,7 +26,7 @@ trait BuildFrom[-From, -A, +C] extends Any {
   def fromSpecific(from: From)(it: IterableOnce[A]): C
 
   /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-    * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
+   * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
   def newBuilder(from: From): mutable.Builder[A, C]
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")
@@ -39,13 +39,15 @@ object BuildFrom {
   implicit def fromCanBuildFrom[From, A, C](
       implicit cbf: CanBuildFrom[From, A, C]): BuildFrom[From, A, C] =
     new BuildFrom[From, A, C] {
-      def fromSpecific(from: From)(it: IterableOnce[A]): C = (cbf(from) ++= it).result()
-      def newBuilder(from: From): mutable.Builder[A, C]        = cbf(from)
+      def fromSpecific(from: From)(it: IterableOnce[A]): C =
+        (cbf(from) ++= it).result()
+      def newBuilder(from: From): mutable.Builder[A, C] = cbf(from)
     }
 
   // Implicit conversion derived from an implicit conversion to CanBuildFrom
   implicit def fromCanBuildFromConversion[X, From, A, C](x: X)(
-      implicit toCanBuildFrom: X => CanBuildFrom[From, A, C]): BuildFrom[From, A, C] =
+      implicit toCanBuildFrom: X => CanBuildFrom[From, A, C])
+    : BuildFrom[From, A, C] =
     fromCanBuildFrom(toCanBuildFrom(x))
 
 }

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/CompatImpl.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/CompatImpl.scala
@@ -17,10 +17,11 @@ import scala.collection.mutable.Builder
 import scala.collection.{immutable => i, mutable => m}
 
 private[compat] object CompatImpl {
-  def simpleCBF[A, C](f: => Builder[A, C]): CanBuildFrom[Any, A, C] = new CanBuildFrom[Any, A, C] {
-    def apply(from: Any): Builder[A, C] = apply()
-    def apply(): Builder[A, C]          = f
-  }
+  def simpleCBF[A, C](f: => Builder[A, C]): CanBuildFrom[Any, A, C] =
+    new CanBuildFrom[Any, A, C] {
+      def apply(from: Any): Builder[A, C] = apply()
+      def apply(): Builder[A, C]          = f
+    }
 
   type ImmutableBitSetCC[X] = ({ type L[_] = i.BitSet })#L[X]
   type MutableBitSetCC[X]   = ({ type L[_] = m.BitSet })#L[X]

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/CompatImpl.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/CompatImpl.scala
@@ -1,0 +1,27 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.compat
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+import scala.collection.{immutable => i, mutable => m}
+
+private[compat] object CompatImpl {
+  def simpleCBF[A, C](f: => Builder[A, C]): CanBuildFrom[Any, A, C] = new CanBuildFrom[Any, A, C] {
+    def apply(from: Any): Builder[A, C] = apply()
+    def apply(): Builder[A, C]          = f
+  }
+
+  type ImmutableBitSetCC[X] = ({ type L[_] = i.BitSet })#L[X]
+  type MutableBitSetCC[X]   = ({ type L[_] = m.BitSet })#L[X]
+}

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -1,0 +1,241 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.compat
+
+import scala.collection.generic._
+import scala.reflect.ClassTag
+import scala.collection.{MapLike, GenTraversable, BitSet, IterableView}
+import scala.collection.{immutable => i, mutable => m}
+import scala.{collection => c}
+
+/** The collection compatibility API */
+private[compat] trait PackageShared {
+  import CompatImpl._
+
+  /**
+   * A factory that builds a collection of type `C` with elements of type `A`.
+   *
+   * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+   */
+  type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
+
+  implicit class FactoryOps[-A, +C](private val factory: Factory[A, C]) {
+
+    /**
+     * @return A collection of type `C` containing the same elements
+     *         as the source collection `it`.
+     * @param it Source collection
+     */
+    def fromSpecific(it: TraversableOnce[A]): C = (factory() ++= it).result()
+
+    /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
+    def newBuilder: m.Builder[A, C] = factory()
+  }
+
+  implicit def genericCompanionToCBF[A, CC[X] <: GenTraversable[X]](
+      fact: GenericCompanion[CC]): CanBuildFrom[Any, A, CC[A]] =
+    simpleCBF(fact.newBuilder[A])
+
+  implicit def sortedSetCompanionToCBF[A: Ordering,
+                                       CC[X] <: c.SortedSet[X] with c.SortedSetLike[X, CC[X]]](
+      fact: SortedSetFactory[CC]): CanBuildFrom[Any, A, CC[A]] =
+    simpleCBF(fact.newBuilder[A])
+
+  implicit def arrayCompanionToCBF[A: ClassTag](fact: Array.type): CanBuildFrom[Any, A, Array[A]] =
+    simpleCBF(Array.newBuilder[A])
+
+  implicit def mapFactoryToCBF[K, V, CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
+      fact: MapFactory[CC]): CanBuildFrom[Any, (K, V), CC[K, V]] =
+    simpleCBF(fact.newBuilder[K, V])
+
+  implicit def sortedMapFactoryToCBF[
+      K: Ordering,
+      V,
+      CC[A, B] <: c.SortedMap[A, B] with c.SortedMapLike[A, B, CC[A, B]]](
+      fact: SortedMapFactory[CC]): CanBuildFrom[Any, (K, V), CC[K, V]] =
+    simpleCBF(fact.newBuilder[K, V])
+
+  implicit def bitSetFactoryToCBF(fact: BitSetFactory[BitSet]): CanBuildFrom[Any, Int, BitSet] =
+    simpleCBF(fact.newBuilder)
+
+  implicit def immutableBitSetFactoryToCBF(
+      fact: BitSetFactory[i.BitSet]): CanBuildFrom[Any, Int, ImmutableBitSetCC[Int]] =
+    simpleCBF(fact.newBuilder)
+
+  implicit def mutableBitSetFactoryToCBF(
+      fact: BitSetFactory[m.BitSet]): CanBuildFrom[Any, Int, MutableBitSetCC[Int]] =
+    simpleCBF(fact.newBuilder)
+
+  implicit class IterableFactoryExtensionMethods[CC[X] <: GenTraversable[X]](
+      private val fact: GenericCompanion[CC]) {
+    def from[A](source: TraversableOnce[A]): CC[A] =
+      fact.apply(source.toSeq: _*)
+  }
+
+  implicit class MapFactoryExtensionMethods[CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
+      private val fact: MapFactory[CC]) {
+    def from[K, V](source: TraversableOnce[(K, V)]): CC[K, V] =
+      fact.apply(source.toSeq: _*)
+  }
+
+  implicit class BitSetFactoryExtensionMethods[
+      C <: scala.collection.BitSet with scala.collection.BitSetLike[C]](
+      private val fact: BitSetFactory[C]) {
+    def fromSpecific(source: TraversableOnce[Int]): C =
+      fact.apply(source.toSeq: _*)
+  }
+
+  private[compat] def build[T, CC](builder: m.Builder[T, CC], source: TraversableOnce[T]): CC = {
+    builder ++= source
+    builder.result()
+  }
+
+  implicit def toImmutableSortedMapExtensions(
+      fact: i.SortedMap.type): ImmutableSortedMapExtensions =
+    new ImmutableSortedMapExtensions(fact)
+
+  implicit def toImmutableListMapExtensions(fact: i.ListMap.type): ImmutableListMapExtensions =
+    new ImmutableListMapExtensions(fact)
+
+  implicit def toImmutableHashMapExtensions(fact: i.HashMap.type): ImmutableHashMapExtensions =
+    new ImmutableHashMapExtensions(fact)
+
+  implicit def toImmutableTreeMapExtensions(fact: i.TreeMap.type): ImmutableTreeMapExtensions =
+    new ImmutableTreeMapExtensions(fact)
+
+  implicit def toImmutableIntMapExtensions(fact: i.IntMap.type): ImmutableIntMapExtensions =
+    new ImmutableIntMapExtensions(fact)
+
+  implicit def toImmutableLongMapExtensions(fact: i.LongMap.type): ImmutableLongMapExtensions =
+    new ImmutableLongMapExtensions(fact)
+
+  implicit def toMutableLongMapExtensions(fact: m.LongMap.type): MutableLongMapExtensions =
+    new MutableLongMapExtensions(fact)
+
+  implicit def toMutableHashMapExtensions(fact: m.HashMap.type): MutableHashMapExtensions =
+    new MutableHashMapExtensions(fact)
+
+  implicit def toMutableListMapExtensions(fact: m.ListMap.type): MutableListMapExtensions =
+    new MutableListMapExtensions(fact)
+
+  implicit def toMutableMapExtensions(fact: m.Map.type): MutableMapExtensions =
+    new MutableMapExtensions(fact)
+
+  implicit def toStreamExtensionMethods[A](stream: Stream[A]): StreamExtensionMethods[A] =
+    new StreamExtensionMethods[A](stream)
+
+  implicit def toSortedExtensionMethods[K, V <: Sorted[K, V]](
+      fact: Sorted[K, V]): SortedExtensionMethods[K, V] =
+    new SortedExtensionMethods[K, V](fact)
+
+  implicit def toIteratorExtensionMethods[A](self: Iterator[A]): IteratorExtensionMethods[A] =
+    new IteratorExtensionMethods[A](self)
+
+  implicit def toTraversableExtensionMethods[A](
+      self: Traversable[A]): TraversableExtensionMethods[A] =
+    new TraversableExtensionMethods[A](self)
+
+  implicit def toTraversableOnceExtensionMethods[A](
+      self: TraversableOnce[A]): TraversableOnceExtensionMethods[A] =
+    new TraversableOnceExtensionMethods[A](self)
+
+  // This really belongs into scala.collection but there's already a package object
+  // in scala-library so we can't add to it
+  type IterableOnce[+X] = c.TraversableOnce[X]
+  val IterableOnce = c.TraversableOnce
+
+  implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
+    new MapViewExtensionMethods[K, V, C](self)
+}
+
+class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {
+  def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.SortedMap[K, V] =
+    build(i.SortedMap.newBuilder[K, V], source)
+}
+
+class ImmutableListMapExtensions(private val fact: i.ListMap.type) extends AnyVal {
+  def from[K, V](source: TraversableOnce[(K, V)]): i.ListMap[K, V] =
+    build(i.ListMap.newBuilder[K, V], source)
+}
+
+class ImmutableHashMapExtensions(private val fact: i.HashMap.type) extends AnyVal {
+  def from[K, V](source: TraversableOnce[(K, V)]): i.HashMap[K, V] =
+    build(i.HashMap.newBuilder[K, V], source)
+}
+
+class ImmutableTreeMapExtensions(private val fact: i.TreeMap.type) extends AnyVal {
+  def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.TreeMap[K, V] =
+    build(i.TreeMap.newBuilder[K, V], source)
+}
+
+class ImmutableIntMapExtensions(private val fact: i.IntMap.type) extends AnyVal {
+  def from[V](source: TraversableOnce[(Int, V)]): i.IntMap[V] =
+    build(i.IntMap.canBuildFrom[Int, V](), source)
+}
+
+class ImmutableLongMapExtensions(private val fact: i.LongMap.type) extends AnyVal {
+  def from[V](source: TraversableOnce[(Long, V)]): i.LongMap[V] =
+    build(i.LongMap.canBuildFrom[Long, V](), source)
+}
+
+class MutableLongMapExtensions(private val fact: m.LongMap.type) extends AnyVal {
+  def from[V](source: TraversableOnce[(Long, V)]): m.LongMap[V] =
+    build(m.LongMap.canBuildFrom[Long, V](), source)
+}
+
+class MutableHashMapExtensions(private val fact: m.HashMap.type) extends AnyVal {
+  def from[K, V](source: TraversableOnce[(K, V)]): m.HashMap[K, V] =
+    build(m.HashMap.canBuildFrom[K, V](), source)
+}
+
+class MutableListMapExtensions(private val fact: m.ListMap.type) extends AnyVal {
+  def from[K, V](source: TraversableOnce[(K, V)]): m.ListMap[K, V] =
+    build(m.ListMap.canBuildFrom[K, V](), source)
+}
+
+class MutableMapExtensions(private val fact: m.Map.type) extends AnyVal {
+  def from[K, V](source: TraversableOnce[(K, V)]): m.Map[K, V] =
+    build(m.Map.canBuildFrom[K, V](), source)
+}
+
+class StreamExtensionMethods[A](private val stream: Stream[A]) extends AnyVal {
+  def lazyAppendedAll(as: => TraversableOnce[A]): Stream[A] = stream.append(as)
+}
+
+class SortedExtensionMethods[K, T <: Sorted[K, T]](private val fact: Sorted[K, T]) {
+  def rangeFrom(from: K): T   = fact.from(from)
+  def rangeTo(to: K): T       = fact.to(to)
+  def rangeUntil(until: K): T = fact.until(until)
+}
+
+class IteratorExtensionMethods[A](private val self: c.Iterator[A]) extends AnyVal {
+  def sameElements[B >: A](that: c.TraversableOnce[B]): Boolean = {
+    self.sameElements(that.iterator)
+  }
+  def concat[B >: A](that: c.TraversableOnce[B]): c.TraversableOnce[B] = self ++ that
+}
+
+class TraversableOnceExtensionMethods[A](private val self: c.TraversableOnce[A]) extends AnyVal {
+  def iterator: Iterator[A] = self.toIterator
+}
+
+class TraversableExtensionMethods[A](private val self: c.Traversable[A]) extends AnyVal {
+  def iterableFactory: GenericCompanion[Traversable] = self.companion
+}
+
+class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](private val self: IterableView[(K, V), C]) extends AnyVal {
+  def mapValues[W, That](f: V => W)(implicit bf: CanBuildFrom[IterableView[(K, V), C], (K, W), That]): That =
+    self.map[(K, W), That] { case (k, v) => (k, f(v)) }
+}

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -48,15 +48,20 @@ private[compat] trait PackageShared {
       fact: GenericCompanion[CC]): CanBuildFrom[Any, A, CC[A]] =
     simpleCBF(fact.newBuilder[A])
 
-  implicit def sortedSetCompanionToCBF[A: Ordering,
-                                       CC[X] <: c.SortedSet[X] with c.SortedSetLike[X, CC[X]]](
+  implicit def sortedSetCompanionToCBF[
+      A: Ordering,
+      CC[X] <: c.SortedSet[X] with c.SortedSetLike[X, CC[X]]](
       fact: SortedSetFactory[CC]): CanBuildFrom[Any, A, CC[A]] =
     simpleCBF(fact.newBuilder[A])
 
-  implicit def arrayCompanionToCBF[A: ClassTag](fact: Array.type): CanBuildFrom[Any, A, Array[A]] =
+  implicit def arrayCompanionToCBF[A: ClassTag](
+      fact: Array.type): CanBuildFrom[Any, A, Array[A]] =
     simpleCBF(Array.newBuilder[A])
 
-  implicit def mapFactoryToCBF[K, V, CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
+  implicit def mapFactoryToCBF[
+      K,
+      V,
+      CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
       fact: MapFactory[CC]): CanBuildFrom[Any, (K, V), CC[K, V]] =
     simpleCBF(fact.newBuilder[K, V])
 
@@ -67,15 +72,16 @@ private[compat] trait PackageShared {
       fact: SortedMapFactory[CC]): CanBuildFrom[Any, (K, V), CC[K, V]] =
     simpleCBF(fact.newBuilder[K, V])
 
-  implicit def bitSetFactoryToCBF(fact: BitSetFactory[BitSet]): CanBuildFrom[Any, Int, BitSet] =
+  implicit def bitSetFactoryToCBF(
+      fact: BitSetFactory[BitSet]): CanBuildFrom[Any, Int, BitSet] =
     simpleCBF(fact.newBuilder)
 
-  implicit def immutableBitSetFactoryToCBF(
-      fact: BitSetFactory[i.BitSet]): CanBuildFrom[Any, Int, ImmutableBitSetCC[Int]] =
+  implicit def immutableBitSetFactoryToCBF(fact: BitSetFactory[i.BitSet])
+    : CanBuildFrom[Any, Int, ImmutableBitSetCC[Int]] =
     simpleCBF(fact.newBuilder)
 
-  implicit def mutableBitSetFactoryToCBF(
-      fact: BitSetFactory[m.BitSet]): CanBuildFrom[Any, Int, MutableBitSetCC[Int]] =
+  implicit def mutableBitSetFactoryToCBF(fact: BitSetFactory[m.BitSet])
+    : CanBuildFrom[Any, Int, MutableBitSetCC[Int]] =
     simpleCBF(fact.newBuilder)
 
   implicit class IterableFactoryExtensionMethods[CC[X] <: GenTraversable[X]](
@@ -84,7 +90,8 @@ private[compat] trait PackageShared {
       fact.apply(source.toSeq: _*)
   }
 
-  implicit class MapFactoryExtensionMethods[CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
+  implicit class MapFactoryExtensionMethods[
+      CC[A, B] <: Map[A, B] with MapLike[A, B, CC[A, B]]](
       private val fact: MapFactory[CC]) {
     def from[K, V](source: TraversableOnce[(K, V)]): CC[K, V] =
       fact.apply(source.toSeq: _*)
@@ -97,7 +104,8 @@ private[compat] trait PackageShared {
       fact.apply(source.toSeq: _*)
   }
 
-  private[compat] def build[T, CC](builder: m.Builder[T, CC], source: TraversableOnce[T]): CC = {
+  private[compat] def build[T, CC](builder: m.Builder[T, CC],
+                                   source: TraversableOnce[T]): CC = {
     builder ++= source
     builder.result()
   }
@@ -106,41 +114,51 @@ private[compat] trait PackageShared {
       fact: i.SortedMap.type): ImmutableSortedMapExtensions =
     new ImmutableSortedMapExtensions(fact)
 
-  implicit def toImmutableListMapExtensions(fact: i.ListMap.type): ImmutableListMapExtensions =
+  implicit def toImmutableListMapExtensions(
+      fact: i.ListMap.type): ImmutableListMapExtensions =
     new ImmutableListMapExtensions(fact)
 
-  implicit def toImmutableHashMapExtensions(fact: i.HashMap.type): ImmutableHashMapExtensions =
+  implicit def toImmutableHashMapExtensions(
+      fact: i.HashMap.type): ImmutableHashMapExtensions =
     new ImmutableHashMapExtensions(fact)
 
-  implicit def toImmutableTreeMapExtensions(fact: i.TreeMap.type): ImmutableTreeMapExtensions =
+  implicit def toImmutableTreeMapExtensions(
+      fact: i.TreeMap.type): ImmutableTreeMapExtensions =
     new ImmutableTreeMapExtensions(fact)
 
-  implicit def toImmutableIntMapExtensions(fact: i.IntMap.type): ImmutableIntMapExtensions =
+  implicit def toImmutableIntMapExtensions(
+      fact: i.IntMap.type): ImmutableIntMapExtensions =
     new ImmutableIntMapExtensions(fact)
 
-  implicit def toImmutableLongMapExtensions(fact: i.LongMap.type): ImmutableLongMapExtensions =
+  implicit def toImmutableLongMapExtensions(
+      fact: i.LongMap.type): ImmutableLongMapExtensions =
     new ImmutableLongMapExtensions(fact)
 
-  implicit def toMutableLongMapExtensions(fact: m.LongMap.type): MutableLongMapExtensions =
+  implicit def toMutableLongMapExtensions(
+      fact: m.LongMap.type): MutableLongMapExtensions =
     new MutableLongMapExtensions(fact)
 
-  implicit def toMutableHashMapExtensions(fact: m.HashMap.type): MutableHashMapExtensions =
+  implicit def toMutableHashMapExtensions(
+      fact: m.HashMap.type): MutableHashMapExtensions =
     new MutableHashMapExtensions(fact)
 
-  implicit def toMutableListMapExtensions(fact: m.ListMap.type): MutableListMapExtensions =
+  implicit def toMutableListMapExtensions(
+      fact: m.ListMap.type): MutableListMapExtensions =
     new MutableListMapExtensions(fact)
 
   implicit def toMutableMapExtensions(fact: m.Map.type): MutableMapExtensions =
     new MutableMapExtensions(fact)
 
-  implicit def toStreamExtensionMethods[A](stream: Stream[A]): StreamExtensionMethods[A] =
+  implicit def toStreamExtensionMethods[A](
+      stream: Stream[A]): StreamExtensionMethods[A] =
     new StreamExtensionMethods[A](stream)
 
   implicit def toSortedExtensionMethods[K, V <: Sorted[K, V]](
       fact: Sorted[K, V]): SortedExtensionMethods[K, V] =
     new SortedExtensionMethods[K, V](fact)
 
-  implicit def toIteratorExtensionMethods[A](self: Iterator[A]): IteratorExtensionMethods[A] =
+  implicit def toIteratorExtensionMethods[A](
+      self: Iterator[A]): IteratorExtensionMethods[A] =
     new IteratorExtensionMethods[A](self)
 
   implicit def toTraversableExtensionMethods[A](
@@ -156,51 +174,61 @@ private[compat] trait PackageShared {
   type IterableOnce[+X] = c.TraversableOnce[X]
   val IterableOnce = c.TraversableOnce
 
-  implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
+  implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](
+      self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
     new MapViewExtensionMethods[K, V, C](self)
 }
 
-class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {
+class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type)
+    extends AnyVal {
   def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.SortedMap[K, V] =
     build(i.SortedMap.newBuilder[K, V], source)
 }
 
-class ImmutableListMapExtensions(private val fact: i.ListMap.type) extends AnyVal {
+class ImmutableListMapExtensions(private val fact: i.ListMap.type)
+    extends AnyVal {
   def from[K, V](source: TraversableOnce[(K, V)]): i.ListMap[K, V] =
     build(i.ListMap.newBuilder[K, V], source)
 }
 
-class ImmutableHashMapExtensions(private val fact: i.HashMap.type) extends AnyVal {
+class ImmutableHashMapExtensions(private val fact: i.HashMap.type)
+    extends AnyVal {
   def from[K, V](source: TraversableOnce[(K, V)]): i.HashMap[K, V] =
     build(i.HashMap.newBuilder[K, V], source)
 }
 
-class ImmutableTreeMapExtensions(private val fact: i.TreeMap.type) extends AnyVal {
+class ImmutableTreeMapExtensions(private val fact: i.TreeMap.type)
+    extends AnyVal {
   def from[K: Ordering, V](source: TraversableOnce[(K, V)]): i.TreeMap[K, V] =
     build(i.TreeMap.newBuilder[K, V], source)
 }
 
-class ImmutableIntMapExtensions(private val fact: i.IntMap.type) extends AnyVal {
+class ImmutableIntMapExtensions(private val fact: i.IntMap.type)
+    extends AnyVal {
   def from[V](source: TraversableOnce[(Int, V)]): i.IntMap[V] =
     build(i.IntMap.canBuildFrom[Int, V](), source)
 }
 
-class ImmutableLongMapExtensions(private val fact: i.LongMap.type) extends AnyVal {
+class ImmutableLongMapExtensions(private val fact: i.LongMap.type)
+    extends AnyVal {
   def from[V](source: TraversableOnce[(Long, V)]): i.LongMap[V] =
     build(i.LongMap.canBuildFrom[Long, V](), source)
 }
 
-class MutableLongMapExtensions(private val fact: m.LongMap.type) extends AnyVal {
+class MutableLongMapExtensions(private val fact: m.LongMap.type)
+    extends AnyVal {
   def from[V](source: TraversableOnce[(Long, V)]): m.LongMap[V] =
     build(m.LongMap.canBuildFrom[Long, V](), source)
 }
 
-class MutableHashMapExtensions(private val fact: m.HashMap.type) extends AnyVal {
+class MutableHashMapExtensions(private val fact: m.HashMap.type)
+    extends AnyVal {
   def from[K, V](source: TraversableOnce[(K, V)]): m.HashMap[K, V] =
     build(m.HashMap.canBuildFrom[K, V](), source)
 }
 
-class MutableListMapExtensions(private val fact: m.ListMap.type) extends AnyVal {
+class MutableListMapExtensions(private val fact: m.ListMap.type)
+    extends AnyVal {
   def from[K, V](source: TraversableOnce[(K, V)]): m.ListMap[K, V] =
     build(m.ListMap.canBuildFrom[K, V](), source)
 }
@@ -214,28 +242,36 @@ class StreamExtensionMethods[A](private val stream: Stream[A]) extends AnyVal {
   def lazyAppendedAll(as: => TraversableOnce[A]): Stream[A] = stream.append(as)
 }
 
-class SortedExtensionMethods[K, T <: Sorted[K, T]](private val fact: Sorted[K, T]) {
+class SortedExtensionMethods[K, T <: Sorted[K, T]](
+    private val fact: Sorted[K, T]) {
   def rangeFrom(from: K): T   = fact.from(from)
   def rangeTo(to: K): T       = fact.to(to)
   def rangeUntil(until: K): T = fact.until(until)
 }
 
-class IteratorExtensionMethods[A](private val self: c.Iterator[A]) extends AnyVal {
+class IteratorExtensionMethods[A](private val self: c.Iterator[A])
+    extends AnyVal {
   def sameElements[B >: A](that: c.TraversableOnce[B]): Boolean = {
     self.sameElements(that.iterator)
   }
-  def concat[B >: A](that: c.TraversableOnce[B]): c.TraversableOnce[B] = self ++ that
+  def concat[B >: A](that: c.TraversableOnce[B]): c.TraversableOnce[B] =
+    self ++ that
 }
 
-class TraversableOnceExtensionMethods[A](private val self: c.TraversableOnce[A]) extends AnyVal {
+class TraversableOnceExtensionMethods[A](private val self: c.TraversableOnce[A])
+    extends AnyVal {
   def iterator: Iterator[A] = self.toIterator
 }
 
-class TraversableExtensionMethods[A](private val self: c.Traversable[A]) extends AnyVal {
+class TraversableExtensionMethods[A](private val self: c.Traversable[A])
+    extends AnyVal {
   def iterableFactory: GenericCompanion[Traversable] = self.companion
 }
 
-class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](private val self: IterableView[(K, V), C]) extends AnyVal {
-  def mapValues[W, That](f: V => W)(implicit bf: CanBuildFrom[IterableView[(K, V), C], (K, W), That]): That =
+class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](
+    private val self: IterableView[(K, V), C])
+    extends AnyVal {
+  def mapValues[W, That](f: V => W)(
+      implicit bf: CanBuildFrom[IterableView[(K, V), C], (K, W), That]): That =
     self.map[(K, W), That] { case (k, v) => (k, f(v)) }
 }

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -53,12 +53,14 @@ abstract class ArraySeq[+T] extends AbstractSeq[T] with IndexedSeq[T] {
   override def stringPrefix = "ArraySeq"
 
   /** Clones this object, including the underlying Array. */
-  override def clone(): ArraySeq[T] = ArraySeq unsafeWrapArray unsafeArray.clone()
+  override def clone(): ArraySeq[T] =
+    ArraySeq unsafeWrapArray unsafeArray.clone()
 
   /** Creates new builder for this collection ==> move to subclasses
    */
   override protected[this] def newBuilder: Builder[T, ArraySeq[T]] =
-    new WrappedArrayBuilder[T](elemTag).mapResult(w => ArraySeq.unsafeWrapArray(w.array))
+    new WrappedArrayBuilder[T](elemTag).mapResult(w =>
+      ArraySeq.unsafeWrapArray(w.array))
 
 }
 
@@ -96,7 +98,8 @@ object ArraySeq {
       case x: Array[Unit]    => new ofUnit(x)
     }).asInstanceOf[ArraySeq[T]]
 
-  implicit def canBuildFrom[T](implicit m: ClassTag[T]): CanBuildFrom[ArraySeq[_], T, ArraySeq[T]] =
+  implicit def canBuildFrom[T](
+      implicit m: ClassTag[T]): CanBuildFrom[ArraySeq[_], T, ArraySeq[T]] =
     new CanBuildFrom[ArraySeq[_], T, ArraySeq[T]] {
       def apply(from: ArraySeq[_]): Builder[T, ArraySeq[T]] =
         ArrayBuilder.make[T]()(m) mapResult ArraySeq.unsafeWrapArray[T]
@@ -105,12 +108,15 @@ object ArraySeq {
     }
 
   @SerialVersionUID(3L)
-  final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ArraySeq[T] with Serializable {
+  final class ofRef[T <: AnyRef](val unsafeArray: Array[T])
+      extends ArraySeq[T]
+      with Serializable {
     lazy val elemTag         = ClassTag[T](unsafeArray.getClass.getComponentType)
     def length: Int          = unsafeArray.length
     def apply(index: Int): T = unsafeArray(index)
     def update(index: Int, elem: T) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofRef[_] =>
         arrayEquals(unsafeArray.asInstanceOf[Array[AnyRef]],
@@ -120,12 +126,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofByte(val unsafeArray: Array[Byte]) extends ArraySeq[Byte] with Serializable {
+  final class ofByte(val unsafeArray: Array[Byte])
+      extends ArraySeq[Byte]
+      with Serializable {
     def elemTag                 = ClassTag.Byte
     def length: Int             = unsafeArray.length
     def apply(index: Int): Byte = unsafeArray(index)
     def update(index: Int, elem: Byte) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -133,12 +142,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofShort(val unsafeArray: Array[Short]) extends ArraySeq[Short] with Serializable {
+  final class ofShort(val unsafeArray: Array[Short])
+      extends ArraySeq[Short]
+      with Serializable {
     def elemTag                  = ClassTag.Short
     def length: Int              = unsafeArray.length
     def apply(index: Int): Short = unsafeArray(index)
     def update(index: Int, elem: Short) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _             => super.equals(that)
@@ -146,12 +158,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofChar(val unsafeArray: Array[Char]) extends ArraySeq[Char] with Serializable {
+  final class ofChar(val unsafeArray: Array[Char])
+      extends ArraySeq[Char]
+      with Serializable {
     def elemTag                 = ClassTag.Char
     def length: Int             = unsafeArray.length
     def apply(index: Int): Char = unsafeArray(index)
     def update(index: Int, elem: Char) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -159,12 +174,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofInt(val unsafeArray: Array[Int]) extends ArraySeq[Int] with Serializable {
+  final class ofInt(val unsafeArray: Array[Int])
+      extends ArraySeq[Int]
+      with Serializable {
     def elemTag                = ClassTag.Int
     def length: Int            = unsafeArray.length
     def apply(index: Int): Int = unsafeArray(index)
     def update(index: Int, elem: Int) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _           => super.equals(that)
@@ -172,12 +190,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofLong(val unsafeArray: Array[Long]) extends ArraySeq[Long] with Serializable {
+  final class ofLong(val unsafeArray: Array[Long])
+      extends ArraySeq[Long]
+      with Serializable {
     def elemTag                 = ClassTag.Long
     def length: Int             = unsafeArray.length
     def apply(index: Int): Long = unsafeArray(index)
     def update(index: Int, elem: Long) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -185,12 +206,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofFloat(val unsafeArray: Array[Float]) extends ArraySeq[Float] with Serializable {
+  final class ofFloat(val unsafeArray: Array[Float])
+      extends ArraySeq[Float]
+      with Serializable {
     def elemTag                  = ClassTag.Float
     def length: Int              = unsafeArray.length
     def apply(index: Int): Float = unsafeArray(index)
     def update(index: Int, elem: Float) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
       case _             => super.equals(that)
@@ -198,12 +222,15 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofDouble(val unsafeArray: Array[Double]) extends ArraySeq[Double] with Serializable {
+  final class ofDouble(val unsafeArray: Array[Double])
+      extends ArraySeq[Double]
+      with Serializable {
     def elemTag                   = ClassTag.Double
     def length: Int               = unsafeArray.length
     def apply(index: Int): Double = unsafeArray(index)
     def update(index: Int, elem: Double) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
       case _              => super.equals(that)
@@ -218,7 +245,8 @@ object ArraySeq {
     def length: Int                = unsafeArray.length
     def apply(index: Int): Boolean = unsafeArray(index)
     def update(index: Int, elem: Boolean) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _               => super.equals(that)
@@ -226,26 +254,30 @@ object ArraySeq {
   }
 
   @SerialVersionUID(3L)
-  final class ofUnit(val unsafeArray: Array[Unit]) extends ArraySeq[Unit] with Serializable {
+  final class ofUnit(val unsafeArray: Array[Unit])
+      extends ArraySeq[Unit]
+      with Serializable {
     def elemTag                 = ClassTag.Unit
     def length: Int             = unsafeArray.length
     def apply(index: Int): Unit = unsafeArray(index)
     def update(index: Int, elem: Unit) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode =
+      MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _            => super.equals(that)
     }
   }
 
-  private[this] def arrayEquals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean = {
+  private[this] def arrayEquals(xs: Array[AnyRef],
+                                ys: Array[AnyRef]): Boolean = {
     if (xs eq ys)
       return true
     if (xs.length != ys.length)
       return false
 
     val len = xs.length
-    var i = 0
+    var i   = 0
     while (i < len) {
       if (xs(i) != ys(i))
         return false

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -1,0 +1,256 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.compat.immutable
+
+import java.util.Arrays
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.AbstractSeq
+import scala.collection.generic._
+import scala.collection.immutable.IndexedSeq
+import scala.collection.mutable.{ArrayBuilder, Builder, WrappedArrayBuilder}
+import scala.reflect.ClassTag
+import scala.util.hashing.MurmurHash3
+
+/**
+ * An immutable array.
+ *
+ * Supports efficient indexed access and has a small memory footprint.
+ *
+ *  @define Coll `ArraySeq`
+ *  @define coll wrapped array
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+abstract class ArraySeq[+T] extends AbstractSeq[T] with IndexedSeq[T] {
+
+  override protected[this] def thisCollection: ArraySeq[T] = this
+
+  /** The tag of the element type */
+  protected[this] def elemTag: ClassTag[T]
+
+  /** The length of the array */
+  def length: Int
+
+  /** The element at given index */
+  def apply(index: Int): T
+
+  /** The underlying array */
+  def unsafeArray: Array[T @uncheckedVariance]
+
+  override def stringPrefix = "ArraySeq"
+
+  /** Clones this object, including the underlying Array. */
+  override def clone(): ArraySeq[T] = ArraySeq unsafeWrapArray unsafeArray.clone()
+
+  /** Creates new builder for this collection ==> move to subclasses
+   */
+  override protected[this] def newBuilder: Builder[T, ArraySeq[T]] =
+    new WrappedArrayBuilder[T](elemTag).mapResult(w => ArraySeq.unsafeWrapArray(w.array))
+
+}
+
+/** A companion object used to create instances of `ArraySeq`.
+ */
+object ArraySeq {
+  // This is reused for all calls to empty.
+  private val EmptyArraySeq           = new ofRef[AnyRef](new Array[AnyRef](0))
+  def empty[T <: AnyRef]: ArraySeq[T] = EmptyArraySeq.asInstanceOf[ArraySeq[T]]
+
+  /**
+   * Wrap an existing `Array` into an `ArraySeq` of the proper primitive specialization type
+   * without copying.
+   *
+   * Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without
+   * copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,
+   * containing `Integer`s. An `ArraySeq[Int]` can be obtained with a cast:
+   * `ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[Int]]`. The values are still
+   * boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
+   * `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
+   * `ClassCastException` at runtime.
+   */
+  def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] =
+    (x.asInstanceOf[Array[_]] match {
+      case null              => null
+      case x: Array[AnyRef]  => new ofRef[AnyRef](x)
+      case x: Array[Int]     => new ofInt(x)
+      case x: Array[Double]  => new ofDouble(x)
+      case x: Array[Long]    => new ofLong(x)
+      case x: Array[Float]   => new ofFloat(x)
+      case x: Array[Char]    => new ofChar(x)
+      case x: Array[Byte]    => new ofByte(x)
+      case x: Array[Short]   => new ofShort(x)
+      case x: Array[Boolean] => new ofBoolean(x)
+      case x: Array[Unit]    => new ofUnit(x)
+    }).asInstanceOf[ArraySeq[T]]
+
+  implicit def canBuildFrom[T](implicit m: ClassTag[T]): CanBuildFrom[ArraySeq[_], T, ArraySeq[T]] =
+    new CanBuildFrom[ArraySeq[_], T, ArraySeq[T]] {
+      def apply(from: ArraySeq[_]): Builder[T, ArraySeq[T]] =
+        ArrayBuilder.make[T]()(m) mapResult ArraySeq.unsafeWrapArray[T]
+      def apply: Builder[T, ArraySeq[T]] =
+        ArrayBuilder.make[T]()(m) mapResult ArraySeq.unsafeWrapArray[T]
+    }
+
+  @SerialVersionUID(3L)
+  final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ArraySeq[T] with Serializable {
+    lazy val elemTag         = ClassTag[T](unsafeArray.getClass.getComponentType)
+    def length: Int          = unsafeArray.length
+    def apply(index: Int): T = unsafeArray(index)
+    def update(index: Int, elem: T) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofRef[_] =>
+        arrayEquals(unsafeArray.asInstanceOf[Array[AnyRef]],
+                    that.unsafeArray.asInstanceOf[Array[AnyRef]])
+      case _ => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofByte(val unsafeArray: Array[Byte]) extends ArraySeq[Byte] with Serializable {
+    def elemTag                 = ClassTag.Byte
+    def length: Int             = unsafeArray.length
+    def apply(index: Int): Byte = unsafeArray(index)
+    def update(index: Int, elem: Byte) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _            => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofShort(val unsafeArray: Array[Short]) extends ArraySeq[Short] with Serializable {
+    def elemTag                  = ClassTag.Short
+    def length: Int              = unsafeArray.length
+    def apply(index: Int): Short = unsafeArray(index)
+    def update(index: Int, elem: Short) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _             => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofChar(val unsafeArray: Array[Char]) extends ArraySeq[Char] with Serializable {
+    def elemTag                 = ClassTag.Char
+    def length: Int             = unsafeArray.length
+    def apply(index: Int): Char = unsafeArray(index)
+    def update(index: Int, elem: Char) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _            => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofInt(val unsafeArray: Array[Int]) extends ArraySeq[Int] with Serializable {
+    def elemTag                = ClassTag.Int
+    def length: Int            = unsafeArray.length
+    def apply(index: Int): Int = unsafeArray(index)
+    def update(index: Int, elem: Int) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _           => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofLong(val unsafeArray: Array[Long]) extends ArraySeq[Long] with Serializable {
+    def elemTag                 = ClassTag.Long
+    def length: Int             = unsafeArray.length
+    def apply(index: Int): Long = unsafeArray(index)
+    def update(index: Int, elem: Long) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _            => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofFloat(val unsafeArray: Array[Float]) extends ArraySeq[Float] with Serializable {
+    def elemTag                  = ClassTag.Float
+    def length: Int              = unsafeArray.length
+    def apply(index: Int): Float = unsafeArray(index)
+    def update(index: Int, elem: Float) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _             => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofDouble(val unsafeArray: Array[Double]) extends ArraySeq[Double] with Serializable {
+    def elemTag                   = ClassTag.Double
+    def length: Int               = unsafeArray.length
+    def apply(index: Int): Double = unsafeArray(index)
+    def update(index: Int, elem: Double) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _              => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofBoolean(val unsafeArray: Array[Boolean])
+      extends ArraySeq[Boolean]
+      with Serializable {
+    def elemTag                    = ClassTag.Boolean
+    def length: Int                = unsafeArray.length
+    def apply(index: Int): Boolean = unsafeArray(index)
+    def update(index: Int, elem: Boolean) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
+      case _               => super.equals(that)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  final class ofUnit(val unsafeArray: Array[Unit]) extends ArraySeq[Unit] with Serializable {
+    def elemTag                 = ClassTag.Unit
+    def length: Int             = unsafeArray.length
+    def apply(index: Int): Unit = unsafeArray(index)
+    def update(index: Int, elem: Unit) { unsafeArray(index) = elem }
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    override def equals(that: Any) = that match {
+      case that: ofUnit => unsafeArray.length == that.unsafeArray.length
+      case _            => super.equals(that)
+    }
+  }
+
+  private[this] def arrayEquals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean = {
+    if (xs eq ys)
+      return true
+    if (xs.length != ys.length)
+      return false
+
+    val len = xs.length
+    var i = 0
+    while (i < len) {
+      if (xs(i) != ys(i))
+        return false
+      i += 1
+    }
+    true
+  }
+}

--- a/sconfig/shared/src/main/scala-2.11_2.12/scala/jdk/CollectionConverters.scala
+++ b/sconfig/shared/src/main/scala-2.11_2.12/scala/jdk/CollectionConverters.scala
@@ -1,0 +1,5 @@
+package scala.jdk
+
+import scala.collection.convert.{DecorateAsJava, DecorateAsScala}
+
+object CollectionConverters extends DecorateAsJava with DecorateAsScala

--- a/sconfig/shared/src/main/scala-2.12/scala/collection/compat/package.scala
+++ b/sconfig/shared/src/main/scala-2.12/scala/collection/compat/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+import scala.collection.{mutable => m}
+
+package object compat extends compat.PackageShared {
+  implicit class MutableTreeMapExtensions2(private val fact: m.TreeMap.type) extends AnyVal {
+    def from[K: Ordering, V](source: TraversableOnce[(K, V)]): m.TreeMap[K, V] =
+      build(m.TreeMap.newBuilder[K, V], source)
+  }
+
+  implicit class MutableSortedMapExtensions(private val fact: m.SortedMap.type) extends AnyVal {
+    def from[K: Ordering, V](source: TraversableOnce[(K, V)]): m.SortedMap[K, V] =
+      build(m.SortedMap.newBuilder[K, V], source)
+  }
+}

--- a/sconfig/shared/src/main/scala-2.12/scala/collection/compat/package.scala
+++ b/sconfig/shared/src/main/scala-2.12/scala/collection/compat/package.scala
@@ -15,13 +15,16 @@ package scala.collection
 import scala.collection.{mutable => m}
 
 package object compat extends compat.PackageShared {
-  implicit class MutableTreeMapExtensions2(private val fact: m.TreeMap.type) extends AnyVal {
+  implicit class MutableTreeMapExtensions2(private val fact: m.TreeMap.type)
+      extends AnyVal {
     def from[K: Ordering, V](source: TraversableOnce[(K, V)]): m.TreeMap[K, V] =
       build(m.TreeMap.newBuilder[K, V], source)
   }
 
-  implicit class MutableSortedMapExtensions(private val fact: m.SortedMap.type) extends AnyVal {
-    def from[K: Ordering, V](source: TraversableOnce[(K, V)]): m.SortedMap[K, V] =
+  implicit class MutableSortedMapExtensions(private val fact: m.SortedMap.type)
+      extends AnyVal {
+    def from[K: Ordering, V](
+        source: TraversableOnce[(K, V)]): m.SortedMap[K, V] =
       build(m.SortedMap.newBuilder[K, V], source)
   }
 }

--- a/sconfig/shared/src/main/scala-2.13/scala/collection/compat/immutable/package.scala
+++ b/sconfig/shared/src/main/scala-2.13/scala/collection/compat/immutable/package.scala
@@ -1,0 +1,18 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.compat
+
+package object immutable {
+  type ArraySeq[+T] = scala.collection.immutable.ArraySeq[T]
+  val ArraySeq = scala.collection.immutable.ArraySeq
+}

--- a/sconfig/shared/src/main/scala-2.13/scala/collection/compat/package.scala
+++ b/sconfig/shared/src/main/scala-2.13/scala/collection/compat/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+package object compat {
+  type Factory[-A, +C] = scala.collection.Factory[A, C]
+  val Factory = scala.collection.Factory
+
+  type BuildFrom[-From, -A, +C] = scala.collection.BuildFrom[From, A, C]
+  val BuildFrom = scala.collection.BuildFrom
+
+  type IterableOnce[+X] = scala.collection.IterableOnce[X]
+  val IterableOnce = scala.collection.IterableOnce
+}

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigException.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigException.scala
@@ -340,7 +340,7 @@ object ConfigException {
     private def makeMessage(
         problems: jl.Iterable[ConfigException.ValidationProblem]): String = {
       val sb = new StringBuilder
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (p <- problems.asScala) {
         sb.append(p.origin.description)
         sb.append(": ")

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigNode.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigNode.scala
@@ -12,7 +12,7 @@ abstract class AbstractConfigNode extends ConfigNode {
 
   override final def render: String = {
     val origText = new StringBuilder
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (t <- tokens.asScala) {
       origText.append(t.tokenText)
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
@@ -15,6 +15,7 @@ import org.ekrich.config.ConfigValue
 import org.ekrich.config.ConfigValueType
 
 import scala.annotation.varargs
+import scala.jdk.CollectionConverters._
 
 object AbstractConfigObject {
 
@@ -41,7 +42,6 @@ object AbstractConfigObject {
     val origins                   = new ju.ArrayList[ConfigOrigin]
     var firstOrigin: ConfigOrigin = null
     var numMerged                 = 0
-    import scala.collection.JavaConverters._
     for (v <- stack.asScala) {
       if (firstOrigin == null) firstOrigin = v.origin
       if (v.isInstanceOf[AbstractConfigObject] && (v
@@ -65,7 +65,6 @@ object AbstractConfigObject {
 
   @varargs private[impl] def mergeOrigins(
       stack: AbstractConfigObject*): ConfigOrigin = {
-    import scala.collection.JavaConverters._
     val javaColl = stack.asJavaCollection
     mergeOrigins(javaColl)
     //throws NotPossibleToResolve

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
@@ -63,7 +63,7 @@ object AbstractConfigValue {
 
   def hasDescendantInList(list: ju.List[AbstractConfigValue],
                           descendant: AbstractConfigValue): Boolean = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (v <- list.asScala) {
       if (v == descendant) return true
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
@@ -2,6 +2,7 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigObject
 import org.ekrich.config.ConfigOrigin
@@ -86,7 +87,6 @@ object ConfigConcatenation {
     else {
       val flattened =
         new ju.ArrayList[AbstractConfigValue](pieces.size)
-      import scala.collection.JavaConverters._
       for (v <- pieces.asScala) {
         if (v.isInstanceOf[ConfigConcatenation])
           flattened.addAll(v.asInstanceOf[ConfigConcatenation].pieces)
@@ -94,7 +94,6 @@ object ConfigConcatenation {
       }
       val consolidated =
         new ju.ArrayList[AbstractConfigValue](flattened.size)
-      import scala.collection.JavaConverters._
       for (v <- flattened.asScala) {
         if (consolidated.isEmpty) consolidated.add(v) else join(consolidated, v)
       }
@@ -122,7 +121,6 @@ final class ConfigConcatenation(origin: ConfigOrigin,
     throw new ConfigException.BugOrBroken(
       "Created concatenation with less than 2 items: " + this)
   var hadUnmergeable = false
-  import scala.collection.JavaConverters._
   for (p <- pieces.asScala) {
     if (p.isInstanceOf[ConfigConcatenation])
       throw new ConfigException.BugOrBroken(
@@ -158,8 +156,6 @@ final class ConfigConcatenation(origin: ConfigOrigin,
   override def resolveSubstitutions(
       context: ResolveContext,
       source: ResolveSource): ResolveResult[_ <: AbstractConfigValue] = {
-
-    import scala.collection.JavaConverters._
 
     if (ConfigImpl.traceSubstitutionsEnabled) {
       val indent = context.depth + 2
@@ -224,7 +220,6 @@ final class ConfigConcatenation(origin: ConfigOrigin,
   override def relativized(prefix: Path): ConfigConcatenation = {
     val newPieces =
       new ju.ArrayList[AbstractConfigValue]
-    import scala.collection.JavaConverters._
     for (p <- pieces.asScala) {
       newPieces.add(p.relativized(prefix))
     }
@@ -248,7 +243,6 @@ final class ConfigConcatenation(origin: ConfigOrigin,
                       indent: Int,
                       atRoot: Boolean,
                       options: ConfigRenderOptions): Unit = {
-    import scala.collection.JavaConverters._
     for (p <- pieces.asScala) {
       p.render(sb, indent, atRoot, options)
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigList

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
@@ -204,7 +204,7 @@ object ConfigDocumentParser {
       // all succeeding tokens
       if (valueCount < 2) {
         var value: AbstractConfigNodeValue = null
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         for (node <- values.asScala) {
           if (node.isInstanceOf[AbstractConfigNodeValue])
             value = node.asInstanceOf[AbstractConfigNodeValue]

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImpl.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImpl.scala
@@ -10,7 +10,7 @@ import java.net.URL
 import java.time.Duration
 import java.{util => ju}
 import java.util.concurrent.Callable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigIncluder

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
@@ -11,7 +11,7 @@ import java.io.ObjectOutputStream
 import java.net.URISyntaxException
 import java.net.URL
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeComplexValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeComplexValue.scala
@@ -14,7 +14,7 @@ abstract class ConfigNodeComplexValue(
 
   override def tokens: ju.Collection[Token] = {
     val tokens = new ju.ArrayList[Token]
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (child <- children.asScala) {
       tokens.addAll(child.tokens)
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import org.ekrich.config.ConfigException
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
     extends AbstractConfigNode {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
@@ -1,6 +1,7 @@
 package org.ekrich.config.impl
 
 import java.{util => ju}
+import scala.jdk.CollectionConverters._
 
 final class ConfigNodeInclude(
     final val children: ju.Collection[AbstractConfigNode],
@@ -10,7 +11,6 @@ final class ConfigNodeInclude(
 
   override def tokens: ju.Collection[Token] = {
     val tokens = new ju.ArrayList[Token]
-    import scala.collection.JavaConverters._
     for (child <- children.asScala) {
       tokens.addAll(child.tokens)
     }
@@ -18,7 +18,6 @@ final class ConfigNodeInclude(
   }
 
   private[impl] def name: String = {
-    import scala.collection.JavaConverters._
     for (n <- children.asScala) {
       if (n.isInstanceOf[ConfigNodeSimpleValue])
         return Tokens

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeObject.scala
@@ -2,7 +2,7 @@ package org.ekrich.config.impl
 
 import org.ekrich.config.ConfigSyntax
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 
 final class ConfigNodeObject private[impl] (

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeRoot.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeRoot.scala
@@ -14,7 +14,7 @@ final class ConfigNodeRoot private[impl] (
     throw new ConfigException.BugOrBroken("Tried to indent the root object")
 
   private[impl] def value: ConfigNodeComplexValue = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (node <- children.asScala) {
       if (node.isInstanceOf[ConfigNodeComplexValue])
         return node.asInstanceOf[ConfigNodeComplexValue]

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigParser.scala
@@ -8,7 +8,7 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 
 import org.ekrich.config._

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/DefaultTransformer.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/DefaultTransformer.scala
@@ -7,7 +7,7 @@ import java.{lang => jl}
 import java.{util => ju}
 import java.util.Collections
 import java.util.Comparator
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.ConfigValueType
 import org.ekrich.config.ConfigValueType._

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
@@ -31,7 +31,7 @@ object Path {
   def newPath(path: String): Path = PathParser.parsePath(path)
 
   private def convert(i: ju.Iterator[Path]): Seq[String] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     i.asScala.toSeq.map(_.first)
   }
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathParser.scala
@@ -143,7 +143,7 @@ object PathParser {
       }
     }
     val pb = new PathBuilder
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (e <- buf.asScala) {
       if (e.sb.length == 0 && !e.canBeEmpty)
         throw new ConfigException.BadPath(

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PropertiesParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PropertiesParser.scala
@@ -9,7 +9,7 @@ import java.{util => ju}
 import java.util.Collections
 import java.util.Comparator
 import java.util.Properties
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveContext.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveContext.scala
@@ -101,7 +101,7 @@ private[impl] final class ResolveContext(
   private[impl] def traceString: String = {
     val separator = ", "
     val sb        = new StringBuilder
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     for (value <- resolveStack.asScala) {
       if (value.isInstanceOf[ConfigReference]) {
         sb.append(value.asInstanceOf[ConfigReference].expression.toString)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveStatus.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveStatus.scala
@@ -25,7 +25,7 @@ object ResolveStatus {
 
   def fromValues(
       values: ju.Collection[_ <: AbstractConfigValue]): ResolveStatus = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     values.asScala.find(_.resolveStatus == ResolveStatus.UNRESOLVED) match {
       case Some(_) => ResolveStatus.UNRESOLVED
       case None    => ResolveStatus.RESOLVED

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
@@ -18,7 +18,7 @@ import java.io.ObjectOutput
 import java.io.ObjectStreamException
 import java.{util => ju}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 
 import org.ekrich.config.Config

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
@@ -16,7 +16,7 @@ import java.time.temporal.TemporalAmount
 import java.{util => ju}
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigException

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
@@ -8,7 +8,7 @@ import java.io.Serializable
 import java.{lang => jl}
 import java.{util => ju}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config._
 import org.ekrich.config.impl.AbstractConfigValue._
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -7,7 +7,7 @@ import java.{lang => jl}
 import java.io.ObjectStreamException
 import java.io.Serializable
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigObject

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
@@ -9,7 +9,7 @@ import java.{lang => jl}
 import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigFactory

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokens.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokens.scala
@@ -159,7 +159,7 @@ object Tokens {
         this.value.iterator) + "}"
     override def toString(): String = {
       val sb = new StringBuilder
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (t <- value.asScala) {
         sb.append(t.toString)
       }


### PR DESCRIPTION
Currently the [scala-collection-compat](https://github.com/scala/scala-collection-compat/) library does not support Scala Native.

Can be removed as 2.11 and 2.12 are dropped.

Removes all 2.13 deprecation warnings.