### PR TITLE
Travis-CI: test on JDK 11, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: required
 
 language: scala
 
-jdk:
-  - openjdk8
-
 scala:
   - 2.11.12
 
@@ -22,11 +19,18 @@ jobs:
   include:
   # stage="test" if no stage is specified
   - env: TEST="scalafmt"
+    jdk: openjdk8
     script: ./scripts/scalafmt --test
   - env: TEST="linux"
+    jdk: openjdk8
+    before_install: ./scripts/travis-os-setup.sh
+    script: sbt +test doc
+  - env: TEST="linux"
+    jdk: openjdk11
     before_install: ./scripts/travis-os-setup.sh
     script: sbt +test doc
   - stage: release
+    jdk: openjdk8
     script: sbt ci-release
 
 cache:


### PR DESCRIPTION
in the Scala 2.13 community build, I'm seeing JDK 11 only test failures

```
[error] Failed: Total 530, Failed 14, Errors 0, Passed 516
[error] Failed tests:
[error] 	ApiExamples
[error] 	org.ekrich.config.impl.PublicApiTest
[error] 	org.ekrich.config.impl.ConfigTest
```

I think they'll show up here as well, with this Travis-CI config change