### PR TITLE
Fixes #55: Scala 3 / Dotty Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All available versions can be seen at the [Maven Repository](https://mvnreposito
 | 2.11.x                 | ✅  |          ✅           |       ✅       |
 | 2.12.x                 | ✅  |          ✅           |      n/a       |
 | 2.13.x                 | ✅  |          ✅           |      n/a       |
-| 3.0.0-M1               | ✅  |          ✅           |      n/a       |
+| 3.0.0-M2               | ✅  |          ✅           |      n/a       |
 
 ## Usage and Help
 [![Scaladoc](https://www.javadoc.io/badge/org.ekrich/sconfig_2.11.svg?label=scaladoc)](https://www.javadoc.io/doc/org.ekrich/sconfig_2.11)
@@ -56,6 +56,7 @@ For specific changes, refer to the releases below.
 
 ## Versions
 
+Release [1.3.5](https://github.com/ekrich/sconfig/releases/tag/v1.3.5) - (2020-11-24)<br/>
 Release [1.3.4](https://github.com/ekrich/sconfig/releases/tag/v1.3.4) - (2020-11-03)<br/>
 Release [1.3.3](https://github.com/ekrich/sconfig/releases/tag/v1.3.3) - (2020-09-14)<br/>
 Release [1.3.2](https://github.com/ekrich/sconfig/releases/tag/v1.3.2) - (2020-09-01)<br/>

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ Compile / console / scalacOptions --= Seq(
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.3"
-val dotty    = "3.0.0-M2-bin-20201112-462a72f-NIGHTLY"
+val dotty    = "3.0.0-M2"
 
 val versionsBase   = Seq(scala211, scala212, scala213, dotty)
 val versionsJVM    = versionsBase
@@ -106,7 +106,7 @@ lazy val sconfig = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .crossType(CrossType.Full)
   .settings(
     scala2or3Source,
-    libraryDependencies += ("org.scala-lang.modules" %%% "scala-collection-compat" % "2.3.0")
+    libraryDependencies += ("org.scala-lang.modules" %%% "scala-collection-compat" % "2.3.1")
   )
   .jvmSettings(
     crossScalaVersions := versionsJVM,

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ Compile / console / scalacOptions --= Seq(
 val scala211 = "2.11.12"
 val scala212 = "2.12.12"
 val scala213 = "2.13.3"
-val dotty    = "3.0.0-M1"
+val dotty    = "3.0.0-M2-bin-20201112-462a72f-NIGHTLY"
 
 val versionsBase   = Seq(scala211, scala212, scala213, dotty)
 val versionsJVM    = versionsBase

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ValidationTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ValidationTest.scala
@@ -113,7 +113,7 @@ class ValidationTest extends TestUtils {
     checkValidationException(e, expecteds)
   }
 
-  @Test @Ignore("https://github.com/lampepfl/dotty/issues/9881")
+  @Test
   def validationFailedSerializable(): Unit = {
     // Reusing a previous test case to generate an error
     val reference = parseConfig("""{ a : [{},{},{}] }""")


### PR DESCRIPTION
All known features and tests now work in Scala 3 and it also supports Scala.js with Scala 3.