### PR TITLE
put `@throws` annotation in the right place

### DIFF
--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
@@ -53,8 +53,7 @@ object Path {
     }
 }
 
-@throws(classOf[ConfigException])
-final class Path(val first: String, val remainder: Path) {
+final class Path @throws(classOf[ConfigException]) (val first: String, val remainder: Path) {
   if (first == null)
     throw new ConfigException.BugOrBroken("empty path")
 


### PR DESCRIPTION
as per scala/bug#12324 and scala/scala#9465

caught by the Scala 2.13 community build