### PR TITLE
add scalafix rule to migrate code from Typesafe Config to sconfig

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ lazy val root = (project in file("."))
     sconfigJVM,
     sconfigNative,
     sconfigJS,
+    scalafix,
     simpleLibScala,
     simpleAppScala,
     complexAppScala,
@@ -174,6 +175,15 @@ lazy val sconfig = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .jsSettings(
     crossScalaVersions := versionsJS,
     libraryDependencies += "org.ekrich" %%% "sjavatime" % javaTime % "provided"
+  )
+
+lazy val scalafix = (project in file("scalafix"))
+  .settings(
+    moduleName := "sconfig-scalafix",
+    crossScalaVersions := versionsBase,
+    libraryDependencies ++= Seq(
+      "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion
+    )
   )
 
 lazy val sharedScala2or3Source: Seq[Setting[_]] = Def.settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % scalaNativ
 // Scala.js support
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossVer)
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.30")

--- a/scalafix/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+org.ekrich.sconfig.scalafix.ReplaceTypesafeConfig

--- a/scalafix/src/main/scala/org/ekrich/sconfig/scalafix/ReplaceTypesafeConfig.scala
+++ b/scalafix/src/main/scala/org/ekrich/sconfig/scalafix/ReplaceTypesafeConfig.scala
@@ -1,0 +1,13 @@
+package org.ekrich.sconfig.scalafix
+
+import scalafix.v1._
+
+class ReplaceTypesafeConfig extends SemanticRule("ReplaceTypesafeConfig") {
+  override def fix(implicit doc: SemanticDocument): Patch =
+    rewritePackages
+
+  def rewritePackages(implicit doc: SemanticDocument): Patch =
+    Patch.replaceSymbols(
+      "com.typesafe.config" -> "org.ekrich.config"
+    )
+}


### PR DESCRIPTION
after publishing, this would be executed by running

```
scalafix dependency:ReplaceTypesafeConfig@org.ekrich:sconfig-scalafix:1.4.5
```

This rule is just a starting point. I think theoretically it could be added to over time, to support additional rewrites like removing the empty parens from certain method calls, etc.