### PR TITLE
Fix for 2.13.12 - return type is needed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
 val dotcOpts = List("-unchecked", "-deprecation", "-feature")
 val scalacOpts = dotcOpts ++ List(
   "-Ywarn-unused:imports",
-  "-Xsource:3"
+  "-Xsource:3",
+  "-Wconf:any:warning-verbose" // -quickfix:any - apply all available quick fixes
 )
 
 Compile / console / scalacOptions --= Seq(

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
@@ -6,7 +6,7 @@ package org.ekrich.config.impl
 import java.{lang => jl}
 import java.{util => ju}
 import scala.util.control.Breaks._
-import scala.collection.mutable.ArrayStack
+import scala.collection.mutable
 import org.ekrich.config._
 
 object ConfigDocumentParser {
@@ -53,7 +53,7 @@ object ConfigDocumentParser {
       val tokens: ju.Iterator[Token]
   ) {
     private var lineNumber = 1
-    final private var buffer = new ArrayStack[Token]
+    final private var buffer = new mutable.Stack[Token]
     // this is the number of "equals" we are inside,
     // used to modify the error message to reflect that
     // someone may think this is .properties format.

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
@@ -9,7 +9,7 @@ import org.ekrich.config.ConfigException
 import scala.collection.mutable
 
 final class PathBuilder private[impl] () {
-  final private val keys = new mutable.ArrayStack[String]
+  final private val keys = new mutable.Stack[String]
   // the keys are kept "backward" (top of stack is end of path)
   private var resultPath: Path = null
 


### PR DESCRIPTION
2.13.12 is very strict with `-Xsource:3`, even more so about explicit return value than Scala 3.

See this fix: https://github.com/scala/scala/pull/10482

https://docs.scala-lang.org/scala3/guides/migration/incompat-type-inference.html