### PR TITLE
Update build to handle 2.13.12 errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,12 @@ val dotcOpts = List("-unchecked", "-deprecation", "-feature")
 val scalacOpts = dotcOpts ++ List(
   "-Ywarn-unused:imports",
   "-Xsource:3",
-  "-Wconf:any:warning-verbose" // -quickfix:any - apply all available quick fixes
+  // 57 inferred return type Scala 2.13 cat=scala3-migration
+  "-Wconf:msg=inferred:ws",
+  // 2 deprecations Scala 2.12 Stack - fixed for 2.13
+  "-Wconf:msg=poorly-performing:ws"
+  // uncomment to see messages
+  // "-Wconf:any:warning-verbose"
 )
 
 Compile / console / scalacOptions --= Seq(


### PR DESCRIPTION
Scala 2.13 deprecated `mutable.ArrayStack` which is replaced with `mutable.Stack` which is `Array` backed. Fixing this triggers a deprecation in Scala 2.12 that `mutable.Stack` is potentially "poorly-performing". Since 2.12 is older, we will ignore this deprecation and silence the warnings.

Scala 2.13.12 creates an error using `-Xsource:3` if a return type is not explicit and the type inferred is not the same as Scala 3. The flag triggers this error because this could create a compatibility problems. Since we have had no problems so far with either type inference result, we will ignore this warning as well. The deprecation warnings are `overrides` on an internal API so it should not be exposed to the end user and create binary incompatibilities in the future. Public APIs should specify the return type.