### PR TITLE
Revert "Revert "Update sbt-scalafix, scalafix-core to 0.13.0""

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 val crossVer = "1.3.2"
 val scalaJSVersion = "1.17.0"
 val scalaNativeVersion = "0.5.5"
-val scalafix = "0.12.1"
+val scalafix = "0.13.0"
 
 // includes sbt-dynver sbt-pgp sbt-sonatype sbt-git
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")


### PR DESCRIPTION
Reverts ekrich/sconfig#396 - This was reverted initially so that the Scala `2.12` and `2.13` versions will be based on the `scalafix` plugin Scala versions. This way the Scala versions can be merged prior to the `scalafix` being upgraded as it we build the matching versions as they are paired as exact versions. I was able to build the project with new Scala and now it should truly build for the newest Scala versions.