### PR TITLE
Making rendering useful for formatting files.

### DIFF
--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -34,11 +34,18 @@ object ConfigRenderOptions {
   def concise = new ConfigRenderOptions(false, false, false, true)
 }
 
+case class FormattingOptions(
+    keepOriginOrder: Boolean = false,
+    doubleIndent: Boolean = false,
+    doubleColonAssign: Boolean = false
+)
+
 final class ConfigRenderOptions private (
     val originComments: Boolean,
     val comments: Boolean,
     val formatted: Boolean,
-    val json: Boolean
+    val json: Boolean,
+    val formattingOptions: FormattingOptions = FormattingOptions()
 ) {
 
   /**
@@ -115,6 +122,26 @@ final class ConfigRenderOptions private (
   def getFormatted: Boolean = formatted
 
   /**
+   * Returns options with formatting options set. Formatting is dependant on formatted flag.
+   *
+   * @param value
+   *   true to enable formatting
+   * @return
+   *   options with requested setting for formatting
+   */
+  def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
+    if (value == formattingOptions) this
+    else new ConfigRenderOptions(originComments, comments, formatted, json, value)
+
+  /**
+   * Returns options used to format the config.
+   *
+   * @return
+   *   FormattingOptions
+   */
+  def getFormattingOptions: FormattingOptions = formattingOptions
+
+  /**
    * Returns options with JSON toggled. JSON means that HOCON extensions
    * (omitting commas, quotes for example) won't be used. However, whether to
    * use comments is controlled by the separate [[#setComments]] and
@@ -143,7 +170,12 @@ final class ConfigRenderOptions private (
     val sb = new StringBuilder("ConfigRenderOptions(")
     if (originComments) sb.append("originComments,")
     if (comments) sb.append("comments,")
-    if (formatted) sb.append("formatted,")
+    if (formatted) {
+      sb.append("formatted,")
+      if (formattingOptions.keepOriginOrder) sb.append("keepOriginOrder,")
+      if (formattingOptions.doubleIndent) sb.append("doubleIndent,")
+      if (formattingOptions.doubleColonAssign) sb.append("equalsAssign,")
+    }
     if (json) sb.append("json,")
     if (sb.charAt(sb.length - 1) == ',') sb.setLength(sb.length - 1)
     sb.append(")")

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -36,8 +36,9 @@ object ConfigRenderOptions {
 
 case class FormattingOptions(
     keepOriginOrder: Boolean = false,
-    doubleIndent: Boolean = false,
-    doubleColonAssign: Boolean = false
+    doubleIndent: Boolean = true,
+    doubleColonAssign: Boolean = false,
+    newLineAtEnd: Boolean = true
 )
 
 final class ConfigRenderOptions private (
@@ -122,7 +123,8 @@ final class ConfigRenderOptions private (
   def getFormatted: Boolean = formatted
 
   /**
-   * Returns options with formatting options set. Formatting is dependant on formatted flag.
+   * Returns options with formatting options set. Formatting is dependant on
+   * formatted flag.
    *
    * @param value
    *   true to enable formatting
@@ -131,7 +133,8 @@ final class ConfigRenderOptions private (
    */
   def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
     if (value == formattingOptions) this
-    else new ConfigRenderOptions(originComments, comments, formatted, json, value)
+    else
+      new ConfigRenderOptions(originComments, comments, formatted, json, value)
 
   /**
    * Returns options used to format the config.

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
@@ -83,7 +83,7 @@ object AbstractConfigValue {
     if (options.getFormatted) {
       var remaining = indent
       while (remaining > 0) {
-        sb.append("    ")
+        sb.append(if (options.formattingOptions.doubleIndent) "    " else "  ")
         remaining -= 1
       }
     }
@@ -337,7 +337,9 @@ abstract class AbstractConfigValue private[impl] (val _origin: ConfigOrigin)
         if (this.isInstanceOf[ConfigObject]) {
           if (options.getFormatted) sb.append(' ')
         } else {
-          sb.append("=")
+          sb.append(
+            if (options.formattingOptions.doubleColonAssign) ":" else "="
+          )
         }
       }
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
@@ -167,7 +167,7 @@ object ConfigDelayedMerge {
       }
     }
     val reversed = new ju.ArrayList[AbstractConfigValue]
-    reversed.addAll(stack)
+    reversed.addAll(stack)  // TODO affected?
     ju.Collections.reverse(reversed)
     var i = 0
     for (v <- reversed.asScala) {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
@@ -167,7 +167,7 @@ object ConfigDelayedMerge {
       }
     }
     val reversed = new ju.ArrayList[AbstractConfigValue]
-    reversed.addAll(stack)  // TODO affected?
+    reversed.addAll(stack) // TODO affected?
     ju.Collections.reverse(reversed)
     var i = 0
     for (v <- reversed.asScala) {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
@@ -167,7 +167,7 @@ object ConfigDelayedMerge {
       }
     }
     val reversed = new ju.ArrayList[AbstractConfigValue]
-    reversed.addAll(stack) // TODO affected?
+    reversed.addAll(stack)
     ju.Collections.reverse(reversed)
     var i = 0
     for (v <- reversed.asScala) {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -571,7 +571,8 @@ final class SimpleConfigObject(
         sb.append("}")
       }
     }
-    if (atRoot && options.getFormatted) sb.append('\n')
+    if (atRoot && options.getFormatted && options.getFormattingOptions.newLineAtEnd)
+      sb.append('\n')
   }
 
   override def get(key: Any): AbstractConfigValue = value.get(key)

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/FormattingOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/FormattingOptionsTest.scala
@@ -82,7 +82,7 @@ class FormattingOptionsTest extends TestUtilsShared {
                      |    }
                      |  }
                      |}
-                     |""".replace("\r", "").stripMargin
+                     |""".stripMargin
     checkEqualObjects(result, expected)
   }
 

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/FormattingOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/FormattingOptionsTest.scala
@@ -1,0 +1,108 @@
+package org.ekrich.config.impl
+import org.junit.Assert.*
+import org.junit.*
+import org.ekrich.config.{
+  ConfigFactory,
+  ConfigParseOptions,
+  ConfigRenderOptions,
+  FormattingOptions
+}
+
+class FormattingOptionsTest extends TestUtilsShared {
+  val parseOptions = ConfigParseOptions.defaults.setAllowMissing(true)
+  val myDefaultRenderOptions = ConfigRenderOptions.defaults
+    .setJson(false)
+    .setOriginComments(false)
+    .setComments(true)
+    .setFormatted(true)
+
+  def formatHocon(
+      str: String
+  )(implicit formattingOptions: FormattingOptions): String =
+    ConfigFactory
+      .parseString(str, parseOptions)
+      .root
+      .render(myDefaultRenderOptions.setFormattingOptions(formattingOptions))
+
+  @Test
+  def noNewLineAtTheEnd(): Unit = {
+    implicit val formattingOptions = FormattingOptions(newLineAtEnd = false)
+    val in = """r {
+               |}""".stripMargin
+    val result = formatHocon(in)
+    val expected = "r {}"
+    checkEqualObjects(result, expected)
+  }
+
+  @Test
+  def keepOriginOrderOfEntries(): Unit = {
+    implicit val formattingOptions = FormattingOptions(keepOriginOrder = true)
+
+    val in = """r {
+               |  p {
+               |        s: ${r.ss}
+               |     }
+               |  f {
+               |    s=t_f
+               |    n="ALA"
+               |  }
+               |}""".stripMargin
+    val result = formatHocon(in)
+
+    val expected = """r {
+                     |    p {
+                     |        s=${r.ss}
+                     |    }
+                     |    f {
+                     |        s="t_f"
+                     |        n=ALA
+                     |    }
+                     |}
+                     |""".stripMargin
+    checkEqualObjects(result, expected)
+  }
+
+  @Test
+  def useTwoSpacesIndentation(): Unit = {
+    implicit val formattingOptions = FormattingOptions(doubleIndent = false)
+
+    val in = """r {
+               |  p {
+               |        d {
+               |        s: ${r.ss}
+               |        }
+               |     }
+               |}""".stripMargin
+    val result = formatHocon(in)
+
+    val expected = """r {
+                     |  p {
+                     |    d {
+                     |      s=${r.ss}
+                     |    }
+                     |  }
+                     |}
+                     |""".replace("\r", "").stripMargin
+    checkEqualObjects(result, expected)
+  }
+
+  @Test
+  def useDoubleColonAsAssignSign(): Unit = {
+    implicit val formattingOptions = FormattingOptions(doubleColonAssign = true)
+
+    val in = """r {
+               |    s=t_f
+               |      n-m=1
+               |    n:"ALA"
+               |}""".stripMargin
+    val result = formatHocon(in)
+
+    val expected = """r {
+                     |    n:ALA
+                     |    "n-m":1
+                     |    s:"t_f"
+                     |}
+                     |""".stripMargin
+    checkEqualObjects(result, expected)
+  }
+}


### PR DESCRIPTION
Added:
- keep origin order of entries,
- switch two/four spaces,
- assing sign switch : or =

Why? lack of good formatter that can be used with git hooks. This lib allows ignoring resolving the references.