### PR TITLE
Release for Scala Native 0.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you wish to avoid the `scalafix` solution above especially if your usage of t
 
 ## Versions
 
+Release [1.10.0](https://github.com/ekrich/sconfig/releases/tag/v1.10.0) - (2025-06-09)<br/>
 Release [1.9.1](https://github.com/ekrich/sconfig/releases/tag/v1.9.1) - (2025-02-27)<br/>
 Release [1.9.0](https://github.com/ekrich/sconfig/releases/tag/v1.9.0) - (2025-03-17)<br/>
 Release [1.8.1](https://github.com/ekrich/sconfig/releases/tag/v1.8.1) - (2024-11-05)<br/>

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ ThisBuild / scalaVersion := scala213
 ThisBuild / crossScalaVersions := versions
 ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / mimaFailOnNoPrevious := false
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
 Compile / packageBin / packageOptions +=
   Package.ManifestAttributes("Automatic-Module-Name" -> "org.ekrich.sconfig")

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ addCommandAlias(
   ).mkString(";", ";", "")
 )
 
-val prevVersion = "1.9.1"
-val nextVersion = "1.9.2"
+val prevVersion = "1.10.0"
+val nextVersion = "1.11.0"
 
 // stable snapshot is not great for publish local
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {


### PR DESCRIPTION
Also change build to use new sbt snapshot setup for central.