### PR TITLE
Fix #256: Potential excess memory use with getDuration

### DIFF
--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
@@ -5,7 +5,7 @@ package org.ekrich.config.impl
 
 import java.io.ObjectStreamException
 import java.io.Serializable
-import java.{lang => jl}
+import java.lang as jl
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.DateTimeException
@@ -13,12 +13,13 @@ import java.time.Duration
 import java.time.Period
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAmount
-import java.{util => ju}
+import java.util as ju
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-import scala.jdk.CollectionConverters._
-import scala.util.control.Breaks._
+import scala.jdk.CollectionConverters.*
+import scala.util.control.Breaks.*
+
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigList
@@ -39,7 +40,7 @@ import org.ekrich.config.ConfigValueType
 @SerialVersionUID(1L)
 object SimpleConfig {
   private val nonNegIntPattern = Pattern.compile("[0-9]+")
-  private val intPattern = Pattern.compile("[+-]?[0-9]+")
+  private val signedIntPattern = Pattern.compile("[+-]?[0-9]+")
 
   private def findPaths(
       entries: ju.Set[ju.Map.Entry[String, ConfigValue]],
@@ -134,13 +135,13 @@ object SimpleConfig {
     }
   private def getUnits(s: String): String = {
     var i = s.length - 1
-    breakable {
-      while (i >= 0) {
-        val c = s.charAt(i)
-        if (!Character.isLetter(c)) break() // break
-        i -= 1
-      }
+    var break = false
+    while (i >= 0 && !break) {
+      val c = s.charAt(i)
+      if (!Character.isLetter(c)) break = true
+      else i -= 1
     }
+
     return s.substring(i + 1)
   }
 
@@ -292,7 +293,7 @@ object SimpleConfig {
       // if the string is purely digits, parse as an integer to avoid
       // possible precision loss;
       // otherwise as a double.
-      if (intPattern.matcher(numberString).matches()) {
+      if (signedIntPattern.matcher(numberString).matches()) {
         units.toNanos(jl.Long.parseLong(numberString))
       } else {
         val nanosInUnit = units.toNanos(1)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
@@ -15,6 +15,7 @@ import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAmount
 import java.{util => ju}
 import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
 
 import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
@@ -37,6 +38,9 @@ import org.ekrich.config.ConfigValueType
  */
 @SerialVersionUID(1L)
 object SimpleConfig {
+  private val nonNegIntPattern = Pattern.compile("[0-9]+")
+  private val intPattern = Pattern.compile("[+-]?[0-9]+")
+
   private def findPaths(
       entries: ju.Set[ju.Map.Entry[String, ConfigValue]],
       parent: Path,
@@ -288,7 +292,7 @@ object SimpleConfig {
       // if the string is purely digits, parse as an integer to avoid
       // possible precision loss;
       // otherwise as a double.
-      if (numberString.matches("[+-]?[0-9]+")) {
+      if (intPattern.matcher(numberString).matches()) {
         units.toNanos(jl.Long.parseLong(numberString))
       } else {
         val nanosInUnit = units.toNanos(1)
@@ -346,7 +350,7 @@ object SimpleConfig {
     try {
       var result: BigInteger = null
       // possible precision loss; otherwise as a double.
-      if (numberString.matches("[0-9]+"))
+      if (nonNegIntPattern.matcher(numberString).matches())
         result = units.bytes.multiply(new BigInteger(numberString))
       else {
         val resultDecimal =


### PR DESCRIPTION
Cache a pre-compiled regex and use a matcher. A `Matcher` gets created but it is not thread safe so better than reusing via the `reset` method.