### PR TITLE
Change ConfigFactory/SimpleConfigObject def to no paren

### DIFF
--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigBeanFactoryTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigBeanFactoryTest.scala
@@ -396,7 +396,7 @@ class ConfigBeanFactoryTest extends TestUtils {
   def testDifferentFieldNameFromAccessors(): Unit = {
     val e = intercept[ConfigException.ValidationFailed] {
       ConfigBeanFactory.create(
-        ConfigFactory.empty(),
+        ConfigFactory.empty,
         classOf[DifferentFieldNameFromAccessorsConfig]
       )
     }

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigValueTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/ConfigValueTest.scala
@@ -251,7 +251,7 @@ class ConfigValueTest extends TestUtils {
 
   @Test
   def configDelayedMergeObjectNotSerializable(): Unit = {
-    val empty = SimpleConfigObject.empty()
+    val empty = SimpleConfigObject.empty
     val s1 = subst("foo")
     val s2 = subst("bar")
     val a = new ConfigDelayedMergeObject(

--- a/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
+++ b/sconfig/jvm/src/test/scala/org/ekrich/config/impl/PublicApiTest.scala
@@ -103,8 +103,8 @@ class PublicApiTest extends TestUtils {
 
   @Test
   def emptyConfigs(): Unit = {
-    assertTrue(ConfigFactory.empty().isEmpty)
-    assertEquals("empty config", ConfigFactory.empty().origin.description)
+    assertTrue(ConfigFactory.empty.isEmpty)
+    assertEquals("empty config", ConfigFactory.empty.origin.description)
     assertTrue(ConfigFactory.empty("foo").isEmpty)
     assertEquals("foo", ConfigFactory.empty("foo").origin.description)
   }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFactory.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFactory.scala
@@ -519,7 +519,7 @@ object ConfigFactory extends PlatformConfigFactory {
    * @return
    *   an empty configuration
    */
-  def empty(): Config = empty(null)
+  def empty: Config = empty(null)
 
   /**
    * Gets an empty configuration with a description to be used to create a

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveSource.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveSource.scala
@@ -180,7 +180,7 @@ final class ResolveSource(
   private def rootMustBeObj(value: Container) =
     if (value.isInstanceOf[AbstractConfigObject])
       value.asInstanceOf[AbstractConfigObject]
-    else SimpleConfigObject.empty()
+    else SimpleConfigObject.empty
   @throws[NotPossibleToResolve]
   private[impl] def lookupSubst(
       context: ResolveContext,
@@ -298,7 +298,7 @@ final class ResolveSource(
           newPath.last.asInstanceOf[AbstractConfigObject],
           newPath
         )
-      else new ResolveSource(SimpleConfigObject.empty())
+      else new ResolveSource(SimpleConfigObject.empty)
     } else if (old eq root) new ResolveSource(rootMustBeObj(replacement))
     else {
       throw new ConfigException.BugOrBroken(

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -145,10 +145,10 @@ object SimpleConfigObject {
 
   private val emptyInstance = empty(SimpleConfigOrigin.newSimple(EMPTY_NAME))
 
-  private[impl] def empty(): SimpleConfigObject = emptyInstance
+  private[impl] def empty: SimpleConfigObject = emptyInstance
 
   private[impl] def empty(origin: ConfigOrigin): SimpleConfigObject =
-    if (origin == null) empty()
+    if (origin == null) empty
     else
       new SimpleConfigObject(
         origin,

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigTest.scala
@@ -28,7 +28,7 @@ class ConfigTest extends TestUtilsShared {
 
   def mergeUnresolved(toMerge: AbstractConfigObject*) = {
     if (toMerge.isEmpty) {
-      SimpleConfigObject.empty()
+      SimpleConfigObject.empty
     } else {
       toMerge.reduce((first, second) => first.withFallback(second))
     }

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigValueSharedTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigValueSharedTest.scala
@@ -201,7 +201,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
 
   @Test
   def configDelayedMergeObjectEquality(): Unit = {
-    val empty = SimpleConfigObject.empty()
+    val empty = SimpleConfigObject.empty
     val s1 = subst("foo")
     val s2 = subst("bar")
     val a = new ConfigDelayedMergeObject(
@@ -232,7 +232,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
     stringValue("hi").toString()
     nullValue().toString()
     boolValue(true).toString()
-    val emptyObj = SimpleConfigObject.empty()
+    val emptyObj = SimpleConfigObject.empty
     emptyObj.toString()
     (new SimpleConfigList(
       fakeOrigin(),
@@ -413,7 +413,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
     unresolved { dm.unwrapped }
 
     // ConfigDelayedMergeObject
-    val emptyObj = SimpleConfigObject.empty()
+    val emptyObj = SimpleConfigObject.empty
     val dmo = new ConfigDelayedMergeObject(
       fakeOrigin(),
       List[AbstractConfigValue](emptyObj, subst("a"), subst("b")).asJava
@@ -728,7 +728,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
   @Test
   def withValueDepth1FromEmpty(): Unit = {
     val v = ConfigValueFactory.fromAnyRef(42: Integer)
-    val config = ConfigFactory.empty().withValue("a", v)
+    val config = ConfigFactory.empty.withValue("a", v)
     assertEquals(parseConfig("a=42"), config)
     assertTrue(config.getValue("a") eq v)
   }
@@ -736,7 +736,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
   @Test
   def withValueDepth2FromEmpty(): Unit = {
     val v = ConfigValueFactory.fromAnyRef(42: Integer)
-    val config = ConfigFactory.empty().withValue("a.b", v)
+    val config = ConfigFactory.empty.withValue("a.b", v)
     assertEquals(parseConfig("a.b=42"), config)
     assertTrue(config.getValue("a.b") eq v)
   }
@@ -744,7 +744,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
   @Test
   def withValueDepth3FromEmpty(): Unit = {
     val v = ConfigValueFactory.fromAnyRef(42: Integer)
-    val config = ConfigFactory.empty().withValue("a.b.c", v)
+    val config = ConfigFactory.empty.withValue("a.b.c", v)
     assertEquals(parseConfig("a.b.c=42"), config)
     assertTrue(config.getValue("a.b.c") eq v)
   }
@@ -785,8 +785,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
     val v2 = ConfigValueFactory.fromAnyRef(2: Integer)
     val v3 = ConfigValueFactory.fromAnyRef(3: Integer)
     val v4 = ConfigValueFactory.fromAnyRef(4: Integer)
-    val config = ConfigFactory
-      .empty()
+    val config = ConfigFactory.empty
       .withValue("a", v1)
       .withValue("b.c", v2)
       .withValue("b.d", v3)
@@ -804,7 +803,7 @@ class ConfigValueSharedTest extends TestUtilsShared {
       SimpleConfigOrigin.newSimple("\n5\n6\n7\n"),
       java.util.Collections.singletonList(v.asInstanceOf[AbstractConfigValue])
     )
-    val conf = ConfigFactory.empty().withValue("bar", list)
+    val conf = ConfigFactory.empty.withValue("bar", list)
     val rendered = conf.root.render
     def assertHas(s: String): Unit =
       assertTrue(s"has ${s.replace("\n", "\\n")} in it", rendered.contains(s))

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/Json4sTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/Json4sTest.scala
@@ -146,7 +146,7 @@ class Json4sTest extends TestUtilsJson4s {
     // be sure we do the same thing as json parser when we build our JSON "DOM"
     for (valid <- whitespaceVariations(validJson, true)) {
       val jsonAST = if (valid.jsonBehaviorUnexpected) {
-        SimpleConfigObject.empty()
+        SimpleConfigObject.empty
       } else {
         addOffendingJsonToException("json", valid.test) {
           fromJsonWithJsonParser(valid.test)


### PR DESCRIPTION
While working on https://github.com/apache/pekko/pull/2187, as part of doing this migration I noticed that I had to change `ConfigFactory.empty` to `ConfigFactory.empty()`. In Scala its idiomatic to have empty parens only on methods that create side effects and `ConfigFactor.empty` has no side effects (its a pure value). Other parts of sconfig already do this (i.e. see [`ValueType`](https://github.com/ekrich/sconfig/blob/87ec47a45052150475176be91dff045a7237450c/sconfig/shared/src/main/scala/org/ekrich/config/ConfigValue.scala#L36) which is correctly missing parens) so I think that having the parens on `ConfigFactory`/`SimpleConfigObject` may have been an oversight.

This change may be source breaking (newer versions of Scala have deprecated the ability to automatically remove empty parens if the method definition has empty parens and vice versa depending on deprecation flags) but its not breaking binary compatibility in any way. The worst that users may have to experience is they would have to remove the parens from `ConfigFactory.empty()` in their Scala source code when updating sconfig to a release that his this fix. Java users are entirely unaffected (in Java you always have these parens for functions, regardless of how its defined in Scala).

