### PR TITLE
Fix #481: Fix ABI before release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,11 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   else nextVersion + "-SNAPSHOT"
 }
 
-val dotcOpts = List("-unchecked", "-deprecation", "-feature")
+val dotcOpts = List(
+  "-unchecked",
+  "-deprecation",
+  "-feature"
+)
 val scalacOpts = dotcOpts ++ List(
   "-Ywarn-unused:imports",
   "-Xsource:3",
@@ -34,6 +38,10 @@ Compile / console / scalacOptions --= Seq(
   // "-Xlint:nonlocal-return", // for 2.12 console
   "-Ywarn-unused:imports",
   "-Xfatal-warnings"
+)
+
+Compile / doc / scalacOptions ++= Seq(
+  "-external-mappings:java\\..*::javadoc::https://docs.oracle.com/en/java/javase/17/docs/api/"
 )
 
 val isScala3 = Def.setting {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/Config.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/Config.scala
@@ -119,7 +119,7 @@ import scala.annotation.varargs
  * <p> Convert a `Config` to a JSON or HOCON string by calling [[#root root]] to
  * get the [[ConfigObject]] and then call [[ConfigValue!.render:String render]]
  * on the root object, `myConfig.root.render`. There's also a variant
- * [[ConfigValue!.render(options:org\.ekrich\.config\.ConfigRenderOptions)* render(ConfigRenderOptions)]]
+ * [[ConfigValue!.render(options:org\.ekrich\.config\.ConfigRenderOptions) render(ConfigRenderOptions)]]
  * inherited from [[ConfigValue]] which allows you to control the format of the
  * rendered string. (See [[ConfigRenderOptions]].) Note that `Config` does not
  * remember the formatting of the original file, so if you load, modify, and

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
@@ -38,8 +38,17 @@ final class ConfigFormatOptions private (
     private val doubleIndent: Boolean,
     private val colonAssign: Boolean,
     private val newLineAtEnd: Boolean,
-    private val simplifyOneEntryNestedObjects: Boolean
+    private val simplifyNestedObjects: Boolean
 ) {
+
+  /**
+   * Set to keep the origin order
+   *
+   * @param value
+   *   true to enable the property, false otherwise
+   * @return
+   *   the new [[ConfigFormatOptions]] object
+   */
   def setKeepOriginOrder(value: Boolean): ConfigFormatOptions =
     if (value == keepOriginOrder) this
     else
@@ -48,11 +57,25 @@ final class ConfigFormatOptions private (
         doubleIndent,
         colonAssign,
         newLineAtEnd,
-        simplifyOneEntryNestedObjects
+        simplifyNestedObjects
       )
 
+  /**
+   * Get the current formatting option value
+   *
+   * @return
+   *   true if set, false otherwise
+   */
   def getKeepOriginOrder: Boolean = keepOriginOrder
 
+  /**
+   * Set to enable double the indent (4 spaces vs 2)
+   *
+   * @param value
+   *   true to enable the property, false otherwise
+   * @return
+   *   the new [[ConfigFormatOptions]] object
+   */
   def setDoubleIndent(value: Boolean): ConfigFormatOptions =
     if (value == doubleIndent) this
     else
@@ -61,11 +84,25 @@ final class ConfigFormatOptions private (
         value,
         colonAssign,
         newLineAtEnd,
-        simplifyOneEntryNestedObjects
+        simplifyNestedObjects
       )
 
+  /**
+   * Get the current formatting option value
+   *
+   * @return
+   *   true if set, false otherwise
+   */
   def getDoubleIndent: Boolean = doubleIndent
 
+  /**
+   * Set to have properties use colons between the name and the value
+   *
+   * @param value
+   *   true to enable the property, false otherwise
+   * @return
+   *   the new [[ConfigFormatOptions]] object
+   */
   def setColonAssign(value: Boolean): ConfigFormatOptions =
     if (value == colonAssign) this
     else
@@ -74,11 +111,25 @@ final class ConfigFormatOptions private (
         doubleIndent,
         value,
         newLineAtEnd,
-        simplifyOneEntryNestedObjects
+        simplifyNestedObjects
       )
 
+  /**
+   * Get the current formatting option value
+   *
+   * @return
+   *   true if set, false otherwise
+   */
   def getColonAssign: Boolean = colonAssign
 
+  /**
+   * Set to have a new line at the end of the file
+   *
+   * @param value
+   *   true to enable the property, false otherwise
+   * @return
+   *   the new [[ConfigFormatOptions]] object
+   */
   def setNewLineAtEnd(value: Boolean): ConfigFormatOptions =
     if (value == newLineAtEnd) this
     else
@@ -87,13 +138,27 @@ final class ConfigFormatOptions private (
         doubleIndent,
         colonAssign,
         value,
-        simplifyOneEntryNestedObjects
+        simplifyNestedObjects
       )
 
+  /**
+   * Get the current formatting option value
+   *
+   * @return
+   *   true if set, false otherwise
+   */
   def getNewLineAtEnd: Boolean = newLineAtEnd
 
-  def setSimplifyOneEntryNestedObjects(value: Boolean): ConfigFormatOptions =
-    if (value == simplifyOneEntryNestedObjects) this
+  /**
+   * Set to simplify nested objects
+   *
+   * @param value
+   *   true to enable the property, false otherwise
+   * @return
+   *   the new [[ConfigFormatOptions]] object
+   */
+  def setSimplifyNestedObjects(value: Boolean): ConfigFormatOptions =
+    if (value == simplifyNestedObjects) this
     else
       new ConfigFormatOptions(
         keepOriginOrder,
@@ -103,6 +168,12 @@ final class ConfigFormatOptions private (
         value
       )
 
-  def getSimplifyOneEntryNestedObjects: Boolean = simplifyOneEntryNestedObjects
+  /**
+   * Get the current formatting option value
+   *
+   * @return
+   *   true if set, false otherwise
+   */
+  def getSimplifyNestedObjects: Boolean = simplifyNestedObjects
 
 }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
@@ -1,0 +1,79 @@
+package org.ekrich.config
+
+object ConfigFormatOptions {
+  def defaults = new ConfigFormatOptions(false, true, false, true, false)
+}
+
+final class ConfigFormatOptions private (
+    keepOriginOrder: Boolean,
+    doubleIndent: Boolean,
+    colonAssign: Boolean,
+    newLineAtEnd: Boolean,
+    simplifyOneEntryNestedObjects: Boolean
+) {
+  def setKeepOriginOrder(value: Boolean): ConfigFormatOptions =
+    if (value == keepOriginOrder) this
+    else
+      new ConfigFormatOptions(
+        value,
+        doubleIndent,
+        colonAssign,
+        newLineAtEnd,
+        simplifyOneEntryNestedObjects
+      )
+
+  def getKeepOriginOrder: Boolean = keepOriginOrder
+
+  def setDoubleIndent(value: Boolean): ConfigFormatOptions =
+    if (value == doubleIndent) this
+    else
+      new ConfigFormatOptions(
+        keepOriginOrder,
+        value,
+        colonAssign,
+        newLineAtEnd,
+        simplifyOneEntryNestedObjects
+      )
+
+  def getDoubleIndent: Boolean = doubleIndent
+
+  def setColonAssign(value: Boolean): ConfigFormatOptions =
+    if (value == colonAssign) this
+    else
+      new ConfigFormatOptions(
+        keepOriginOrder,
+        doubleIndent,
+        value,
+        newLineAtEnd,
+        simplifyOneEntryNestedObjects
+      )
+
+  def getColonAssign: Boolean = colonAssign
+
+  def setNewLineAtEnd(value: Boolean): ConfigFormatOptions =
+    if (value == newLineAtEnd) this
+    else
+      new ConfigFormatOptions(
+        keepOriginOrder,
+        doubleIndent,
+        colonAssign,
+        value,
+        simplifyOneEntryNestedObjects
+      )
+
+  def getNewLineAtEnd: Boolean = newLineAtEnd
+
+  def setSimplifyOneEntryNestedObjects(value: Boolean): ConfigFormatOptions =
+    if (value == simplifyOneEntryNestedObjects) this
+    else
+      new ConfigFormatOptions(
+        keepOriginOrder,
+        doubleIndent,
+        colonAssign,
+        newLineAtEnd,
+        value
+      )
+
+  def getSimplifyOneEntryNestedObjects: Boolean = simplifyOneEntryNestedObjects
+
+}

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigFormatOptions.scala
@@ -1,15 +1,44 @@
 package org.ekrich.config
 
+/**
+ * A set of options related to formatting.
+ *
+ * This object is immutable, so the "setters" return a new object.
+ *
+ * Here is an example of creating a custom `ConfigFormatOptions` and change two
+ * defaults:
+ *
+ * {{{
+ * val options = ConfigFormatOptions.defaults()
+ *   .setKeepOriginOrder(true)
+ *   .setDoubleIndent(false)
+ * }}}
+ *
+ * @since 1.12.0
+ */
 object ConfigFormatOptions {
+
+  /**
+   * Create a `ConfigFormatOptions` object with the default values.
+   *
+   * @return
+   *   the default options
+   *
+   *   - keepOriginOrder = false
+   *   - doubleIndent = true
+   *   - colonAssign = false
+   *   - newLineAtEnd = true
+   *   - simplifyOneEntryNestedObjects = false
+   */
   def defaults = new ConfigFormatOptions(false, true, false, true, false)
 }
 
 final class ConfigFormatOptions private (
-    keepOriginOrder: Boolean,
-    doubleIndent: Boolean,
-    colonAssign: Boolean,
-    newLineAtEnd: Boolean,
-    simplifyOneEntryNestedObjects: Boolean
+    private val keepOriginOrder: Boolean,
+    private val doubleIndent: Boolean,
+    private val colonAssign: Boolean,
+    private val newLineAtEnd: Boolean,
+    private val simplifyOneEntryNestedObjects: Boolean
 ) {
   def setKeepOriginOrder(value: Boolean): ConfigFormatOptions =
     if (value == keepOriginOrder) this

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
@@ -7,7 +7,8 @@ import java.math as jm
 
 /**
  * An immutable class representing an amount of memory. Use static factory
- * methods such as [[ConfigMemorySize#ofBytes(bytes:Long)*]] to create instances.
+ * methods such as [[ConfigMemorySize#ofBytes(bytes:Long)*]] to create
+ * instances.
  *
  * @since 1.3.0
  */

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
@@ -7,7 +7,7 @@ import java.math as jm
 
 /**
  * An immutable class representing an amount of memory. Use static factory
- * methods such as [[ConfigMemorySize#ofBytes]] to create instances.
+ * methods such as [[ConfigMemorySize#ofBytes(bytes:Long)*]] to create instances.
  *
  * @since 1.3.0
  */

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
@@ -37,11 +37,17 @@ object ConfigMemorySize {
 
 }
 
-final class ConfigMemorySize private (private val bytes: jm.BigInteger) {
-  if (bytes.signum() < 0)
+final class ConfigMemorySize private (private val _bytes: jm.BigInteger) {
+  if (_bytes.signum() < 0)
     throw new IllegalArgumentException(
-      "Attempt to construct ConfigMemorySize with negative number: " + bytes
+      "Attempt to construct ConfigMemorySize with negative number: " + _bytes
     )
+
+  @deprecated(
+    "Use toBytes",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def bytes: Long = toBytes
 
   /**
    * Gets the size in bytes.
@@ -54,10 +60,10 @@ final class ConfigMemorySize private (private val bytes: jm.BigInteger) {
    *   value. Consider using {@link #toBytesBigInteger} in this case.
    */
   def toBytes: Long =
-    if (bytes.bitLength() < 64) bytes.longValue()
+    if (_bytes.bitLength() < 64) _bytes.longValue()
     else
       throw new IllegalArgumentException(
-        "size-in-bytes value is out of range for a 64-bit long: '" + bytes + "'"
+        "size-in-bytes value is out of range for a 64-bit long: '" + _bytes + "'"
       )
 
   /**
@@ -69,18 +75,18 @@ final class ConfigMemorySize private (private val bytes: jm.BigInteger) {
    * @return
    *   how many bytes
    */
-  def toBytesBigInteger: jm.BigInteger = bytes
+  def toBytesBigInteger: jm.BigInteger = _bytes
 
-  override def toString: String = "ConfigMemorySize(" + bytes + ")"
+  override def toString: String = "ConfigMemorySize(" + _bytes + ")"
 
   override def equals(other: Any): Boolean =
     other match {
-      case size: ConfigMemorySize => size.bytes.equals(this.bytes)
+      case size: ConfigMemorySize => size._bytes.equals(this._bytes)
       case _                      => false
     }
 
   override def hashCode: Int =
-    // in Java 8 this can become Long.hashCode(bytes)
-    // Long.valueOf(bytes).hashCode
-    bytes.hashCode()
+    // in Java 8 this can become Long.hashCode(_bytes)
+    // Long.valueOf(_bytes).hashCode
+    _bytes.hashCode()
 }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigMemorySize.scala
@@ -7,7 +7,7 @@ import java.math as jm
 
 /**
  * An immutable class representing an amount of memory. Use static factory
- * methods such as [[ConfigMemorySize#ofBytes(bytes:Long)*]] to create
+ * methods such as [[ConfigMemorySize$.ofBytes(bytes:Long)*]] to create
  * instances.
  *
  * @since 1.3.0
@@ -56,9 +56,9 @@ final class ConfigMemorySize private (private val _bytes: jm.BigInteger) {
    * @since 1.3.0
    * @return
    *   how many bytes
-   * @exception
-   *   IllegalArgumentException when memory value in bytes doesn't fit in a long
-   *   value. Consider using {@link #toBytesBigInteger} in this case.
+   * @throws java.lang.IllegalArgumentException
+   *   when memory value in bytes doesn't fit in a long value. Consider using
+   *   [[ConfigMemorySize!.toBytesBigInteger]] in this case.
    */
   def toBytes: Long =
     if (_bytes.bitLength() < 64) _bytes.longValue()
@@ -69,9 +69,9 @@ final class ConfigMemorySize private (private val _bytes: jm.BigInteger) {
 
   /**
    * Gets the size in bytes. The behavior of this method is the same as that of
-   * the {@link # toBytes ( )} method, except that the number of bytes returned
-   * as a BigInteger value. Use it when memory value in bytes doesn't fit in a
-   * long value.
+   * the [[ConfigMemorySize!.toBytes]] method, except that the number of bytes
+   * returned as a BigInteger value and it won't throw an exception. Use it when
+   * memory value in bytes doesn't fit in a long value.
    *
    * @return
    *   how many bytes

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
@@ -9,12 +9,15 @@ import org.ekrich.config.impl.PlatformThread
 /**
  * A set of options related to parsing.
  *
- * <p> This object is immutable, so the "setters" return a new object.
+ * This object is immutable, so the "setters" return a new object.
  *
- * <p> Here is an example of creating a custom `ConfigParseOptions`:
+ * Here is an example of creating a custom `ConfigParseOptions`:
  *
- * <pre> ConfigParseOptions options = ConfigParseOptions.defaults()
- * .setSyntax(ConfigSyntax.JSON) .setAllowMissing(false) </pre>
+ * {{{
+ * val options = ConfigParseOptions.defaults()
+ *   .setSyntax(ConfigSyntax.JSON)
+ *   .setAllowMissing(false)
+ * }}}
  */
 object ConfigParseOptions {
 
@@ -29,40 +32,40 @@ object ConfigParseOptions {
 }
 
 final class ConfigParseOptions private (
-    _syntax: ConfigSyntax,
-    _originDescription: String,
-    _allowMissing: Boolean,
-    _includer: ConfigIncluder,
-    _classLoader: ClassLoader
+    private val _syntax: ConfigSyntax,
+    private val _originDescription: String,
+    private val _allowMissing: Boolean,
+    private val _includer: ConfigIncluder,
+    private val _classLoader: ClassLoader
 ) {
 
   @deprecated(
     "Use getSyntax",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def syntax = _syntax
 
   @deprecated(
     "Use getOriginDescription",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def originDescription = _originDescription
 
   @deprecated(
     "Use getAllowMissing",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def allowMissing = _allowMissing
 
   @deprecated(
     "Use getIncluder",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def includer = _includer
 
   @deprecated(
     "Use getClassLoader",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def classLoader = _classLoader
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
@@ -29,12 +29,42 @@ object ConfigParseOptions {
 }
 
 final class ConfigParseOptions private (
-    syntax: ConfigSyntax,
-    originDescription: String,
-    allowMissing: Boolean,
-    includer: ConfigIncluder,
-    classLoader: ClassLoader
+    _syntax: ConfigSyntax,
+    _originDescription: String,
+    _allowMissing: Boolean,
+    _includer: ConfigIncluder,
+    _classLoader: ClassLoader
 ) {
+
+  @deprecated(
+    "Use getSyntax",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def syntax = _syntax
+
+  @deprecated(
+    "Use getOriginDescription",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def originDescription = _originDescription
+
+  @deprecated(
+    "Use getAllowMissing",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def allowMissing = _allowMissing
+
+  @deprecated(
+    "Use getIncluder",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def includer = _includer
+
+  @deprecated(
+    "Use getClassLoader",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def classLoader = _classLoader
 
   /**
    * Set the file format. If set to null, try to guess from any available
@@ -46,14 +76,14 @@ final class ConfigParseOptions private (
    *   options with the syntax set
    */
   def setSyntax(syntax: ConfigSyntax): ConfigParseOptions =
-    if (this.syntax == syntax) this
+    if (_syntax == syntax) this
     else
       new ConfigParseOptions(
         syntax,
-        this.originDescription,
-        this.allowMissing,
-        this.includer,
-        this.classLoader
+        _originDescription,
+        _allowMissing,
+        _includer,
+        _classLoader
       )
 
   /**
@@ -75,7 +105,7 @@ final class ConfigParseOptions private (
    * @return
    *   the current syntax or null
    */
-  def getSyntax: ConfigSyntax = syntax
+  def getSyntax: ConfigSyntax = _syntax
 
   /**
    * Set a description for the thing being parsed. In most cases this will be
@@ -90,17 +120,17 @@ final class ConfigParseOptions private (
    *   options with the origin description set
    */
   def setOriginDescription(originDescription: String): ConfigParseOptions = { // findbugs complains about == here but is wrong, do not "fix"
-    if (this.originDescription == originDescription)
+    if (_originDescription == originDescription)
       this
-    else if (this.originDescription != null && originDescription != null && this.originDescription == originDescription)
+    else if (_originDescription != null && originDescription != null && _originDescription == originDescription)
       this
     else
       new ConfigParseOptions(
-        this.syntax,
+        _syntax,
         originDescription,
-        this.allowMissing,
-        this.includer,
-        this.classLoader
+        _allowMissing,
+        _includer,
+        _classLoader
       )
   }
 
@@ -110,11 +140,11 @@ final class ConfigParseOptions private (
    * @return
    *   the current origin description or null
    */
-  def getOriginDescription: String = originDescription
+  def getOriginDescription: String = _originDescription
 
   /** this is package-private, not public API */
   private[config] def withFallbackOriginDescription(originDescription: String) =
-    if (this.originDescription == null)
+    if (_originDescription == null)
       setOriginDescription(originDescription)
     else
       this
@@ -131,15 +161,15 @@ final class ConfigParseOptions private (
    *   options with the "allow missing" flag set
    */
   def setAllowMissing(allowMissing: Boolean): ConfigParseOptions =
-    if (this.allowMissing == allowMissing)
+    if (_allowMissing == allowMissing)
       this
     else
       new ConfigParseOptions(
-        this.syntax,
-        this.originDescription,
+        _syntax,
+        _originDescription,
         allowMissing,
-        this.includer,
-        this.classLoader
+        _includer,
+        _classLoader
       )
 
   /**
@@ -148,7 +178,7 @@ final class ConfigParseOptions private (
    * @return
    *   whether we allow missing files
    */
-  def getAllowMissing: Boolean = allowMissing
+  def getAllowMissing: Boolean = _allowMissing
 
   /**
    * Set a [[ConfigIncluder]] which customizes how includes are handled. null
@@ -160,15 +190,15 @@ final class ConfigParseOptions private (
    *   new version of the parse options with different includer
    */
   def setIncluder(includer: ConfigIncluder): ConfigParseOptions =
-    if (this.includer == includer)
+    if (_includer == includer)
       this
     else
       new ConfigParseOptions(
-        this.syntax,
-        this.originDescription,
-        this.allowMissing,
+        _syntax,
+        _originDescription,
+        _allowMissing,
         includer,
-        this.classLoader
+        _classLoader
       )
 
   /**
@@ -184,10 +214,10 @@ final class ConfigParseOptions private (
   def prependIncluder(includer: ConfigIncluder): ConfigParseOptions = {
     if (includer == null)
       throw new NullPointerException("null includer passed to prependIncluder")
-    if (this.includer eq includer)
+    if (_includer eq includer)
       this
-    else if (this.includer != null)
-      setIncluder(includer.withFallback(this.includer))
+    else if (_includer != null)
+      setIncluder(includer.withFallback(_includer))
     else
       setIncluder(includer)
   }
@@ -205,10 +235,10 @@ final class ConfigParseOptions private (
   def appendIncluder(includer: ConfigIncluder): ConfigParseOptions = {
     if (includer == null)
       throw new NullPointerException("null includer passed to appendIncluder")
-    if (this.includer == includer)
+    if (_includer == includer)
       this
-    else if (this.includer != null)
-      setIncluder(this.includer.withFallback(includer))
+    else if (_includer != null)
+      setIncluder(_includer.withFallback(includer))
     else
       setIncluder(includer)
   }
@@ -219,7 +249,7 @@ final class ConfigParseOptions private (
    * @return
    *   current includer or null
    */
-  def getIncluder: ConfigIncluder = includer
+  def getIncluder: ConfigIncluder = _includer
 
   /**
    * Set the class loader. If set to null,
@@ -231,14 +261,14 @@ final class ConfigParseOptions private (
    *   options with the class loader set
    */
   def setClassLoader(loader: ClassLoader): ConfigParseOptions =
-    if (this.classLoader == loader)
+    if (_classLoader == loader)
       this
     else
       new ConfigParseOptions(
-        this.syntax,
-        this.originDescription,
-        this.allowMissing,
-        this.includer,
+        _syntax,
+        _originDescription,
+        _allowMissing,
+        _includer,
         loader
       )
 
@@ -250,10 +280,10 @@ final class ConfigParseOptions private (
    *   class loader to use
    */
   def getClassLoader: ClassLoader =
-    if (this.classLoader == null) {
+    if (_classLoader == null) {
       val thread = Thread.currentThread
       new PlatformThread(thread).getContextClassLoader()
     } else {
-      this.classLoader
+      _classLoader
     }
 }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigParseOptions.scala
@@ -29,11 +29,11 @@ object ConfigParseOptions {
 }
 
 final class ConfigParseOptions private (
-    val syntax: ConfigSyntax,
-    val originDescription: String,
-    val allowMissing: Boolean,
-    val includer: ConfigIncluder,
-    val classLoader: ClassLoader
+    syntax: ConfigSyntax,
+    originDescription: String,
+    allowMissing: Boolean,
+    includer: ConfigIncluder,
+    classLoader: ClassLoader
 ) {
 
   /**

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -363,7 +363,7 @@ final class ConfigRenderOptions private (
       if (_configFormatOptions.getDoubleIndent) sb.append("doubleIndent,")
       if (_configFormatOptions.getColonAssign) sb.append("colonAssign,")
       if (_configFormatOptions.getNewLineAtEnd) sb.append("newLineAtEnd,")
-      if (_configFormatOptions.getSimplifyOneEntryNestedObjects)
+      if (_configFormatOptions.getSimplifyNestedObjects)
         sb.append("simplifyOneEntryNestedObjects,")
     }
     if (_json) sb.append("json,")

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -21,8 +21,14 @@ object ConfigRenderOptions {
    * @return
    *   the default render options
    */
-  def defaults =
-    new ConfigRenderOptions(true, true, true, true, true, FormattingOptions())
+  def defaults = new ConfigRenderOptions(
+    true,
+    true,
+    true,
+    true,
+    true,
+    ConfigFormatOptions.defaults
+  )
 
   /**
    * Returns concise render options (no whitespace or comments). For a resolved
@@ -37,25 +43,25 @@ object ConfigRenderOptions {
     false,
     true,
     true,
-    FormattingOptions()
+    ConfigFormatOptions.defaults
   )
 }
 
+@deprecated("Use getConfigFormatOptions", "Since 1.10.0, will remove in 1.12.0")
 case class FormattingOptions(
     keepOriginOrder: Boolean = false,
     doubleIndent: Boolean = true,
     colonAssign: Boolean = false,
-    newLineAtEnd: Boolean = true,
-    simplifyOneEntryNestedObjects: Boolean = false
+    newLineAtEnd: Boolean = true
 )
 
 final class ConfigRenderOptions private (
-    val originComments: Boolean,
-    val comments: Boolean,
-    val formatted: Boolean,
-    val json: Boolean,
-    val showEnvVariableValues: Boolean,
-    val formattingOptions: FormattingOptions
+    private val originComments: Boolean,
+    comments: Boolean,
+    formatted: Boolean,
+    json: Boolean,
+    showEnvVariableValues: Boolean,
+    configFormatOptions: ConfigFormatOptions
 ) {
 
   /**
@@ -77,7 +83,7 @@ final class ConfigRenderOptions private (
         formatted,
         json,
         showEnvVariableValues,
-        formattingOptions
+        configFormatOptions
       )
 
   /**
@@ -113,7 +119,7 @@ final class ConfigRenderOptions private (
         formatted,
         json,
         showEnvVariableValues,
-        formattingOptions
+        configFormatOptions
       )
 
   /**
@@ -143,7 +149,7 @@ final class ConfigRenderOptions private (
         value,
         json,
         showEnvVariableValues,
-        formattingOptions
+        configFormatOptions
       )
 
   /**
@@ -156,16 +162,15 @@ final class ConfigRenderOptions private (
   def getFormatted: Boolean = formatted
 
   /**
-   * Returns new render options with formatting options set. Formatting is
-   * dependant on formatted flag.
+   * Set the config format options. Formatting is dependant on formatted flag.
    *
    * @param value
-   *   true to enable formatting
+   *   the new ConfigFormatOptions object
    * @return
-   *   options with requested setting for formatting
+   *   the new ConfigRenderOptions object with the new formatting setting
    */
-  def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
-    if (value == formattingOptions) this
+  def setConfigFormatOptions(value: ConfigFormatOptions): ConfigRenderOptions =
+    if (value == configFormatOptions) this
     else
       new ConfigRenderOptions(
         originComments,
@@ -180,9 +185,61 @@ final class ConfigRenderOptions private (
    * Returns options used to format the config.
    *
    * @return
-   *   FormattingOptions
+   *   the config format option
    */
-  def getFormattingOptions: FormattingOptions = formattingOptions
+  def getConfigFormatOptions: ConfigFormatOptions = configFormatOptions
+
+  /**
+   * Returns new render options with formatting options set. Formatting is
+   * dependant on formatted flag.
+   *
+   * @param value
+   *   true to enable formatting
+   * @return
+   *   options with requested setting for formatting
+   */
+  @deprecated(
+    "Use setConfigFormatOptions",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
+    if (value == convert(configFormatOptions)) this
+    else
+      new ConfigRenderOptions(
+        originComments,
+        comments,
+        formatted,
+        json,
+        showEnvVariableValues,
+        convert(value)
+      )
+
+  private def convert(value: FormattingOptions): ConfigFormatOptions =
+    ConfigFormatOptions.defaults
+      .setKeepOriginOrder(value.keepOriginOrder)
+      .setDoubleIndent(value.doubleIndent)
+      .setColonAssign(value.colonAssign)
+      .setNewLineAtEnd(value.newLineAtEnd)
+
+  private def convert(value: ConfigFormatOptions): FormattingOptions =
+    FormattingOptions(
+      value.getKeepOriginOrder,
+      value.getDoubleIndent,
+      value.getColonAssign,
+      value.getNewLineAtEnd
+    )
+
+  @deprecated(
+    "Use getConfigFormatOptions",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def formattingOptions: FormattingOptions = convert(configFormatOptions)
+
+  @deprecated(
+    "Use getConfigFormatOptions",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def getFormattingOptions: FormattingOptions = convert(configFormatOptions)
 
   /**
    * Returns options with JSON toggled. JSON means that HOCON extensions
@@ -205,7 +262,7 @@ final class ConfigRenderOptions private (
         formatted,
         value,
         showEnvVariableValues,
-        formattingOptions
+        configFormatOptions
       )
 
   /**
@@ -235,7 +292,7 @@ final class ConfigRenderOptions private (
         formatted,
         json,
         value,
-        formattingOptions
+        configFormatOptions
       )
 
   /**
@@ -254,10 +311,11 @@ final class ConfigRenderOptions private (
     if (comments) sb.append("comments,")
     if (formatted) {
       sb.append("formatted,")
-      if (formattingOptions.keepOriginOrder) sb.append("keepOriginOrder,")
-      if (formattingOptions.doubleIndent) sb.append("doubleIndent,")
-      if (formattingOptions.colonAssign) sb.append("colonAssign,")
-      if (formattingOptions.simplifyOneEntryNestedObjects)
+      if (configFormatOptions.getKeepOriginOrder) sb.append("keepOriginOrder,")
+      if (configFormatOptions.getDoubleIndent) sb.append("doubleIndent,")
+      if (configFormatOptions.getColonAssign) sb.append("colonAssign,")
+      if (configFormatOptions.getNewLineAtEnd) sb.append("newLineAtEnd,")
+      if (configFormatOptions.getSimplifyOneEntryNestedObjects)
         sb.append("simplifyOneEntryNestedObjects,")
     }
     if (json) sb.append("json,")

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -4,12 +4,14 @@
 package org.ekrich.config
 
 /**
- * <p> A set of options related to rendering a [[ConfigValue]]. Passed to
+ * A set of options related to rendering a [[ConfigValue]]. Passed to
  * [[ConfigValue!.render(options:org\.ekrich\.config\.ConfigRenderOptions)* ConfigValue.render(ConfigRenderOptions)]].
  *
- * <p> Here is an example of creating a `ConfigRenderOptions`:
+ * Here is an example of creating a `ConfigRenderOptions`:
  *
- * <pre> val options = ConfigRenderOptions.defaults.setComments(false) </pre>
+ * {{{
+ * val options = ConfigRenderOptions.defaults.setComments(false)
+ * }}}
  */
 object ConfigRenderOptions {
 
@@ -20,6 +22,13 @@ object ConfigRenderOptions {
    *
    * @return
    *   the default render options
+   *
+   *   - originComments = true
+   *   - comments = true
+   *   - formatted = true
+   *   - json = true
+   *   - showEnvVariableValues = true
+   *   - configFormatOptions = [[ConfigFormatOptions#default]]
    */
   def defaults = new ConfigRenderOptions(
     true,
@@ -36,6 +45,13 @@ object ConfigRenderOptions {
    *
    * @return
    *   the concise render options
+   *
+   *   - originComments = false
+   *   - comments = false
+   *   - formatted = false
+   *   - json = true
+   *   - showEnvVariableValues = true
+   *   - configFormatOptions = [[ConfigFormatOptions#default]]
    */
   def concise = new ConfigRenderOptions(
     false,
@@ -47,7 +63,7 @@ object ConfigRenderOptions {
   )
 }
 
-@deprecated("Use getConfigFormatOptions", "Since 1.10.0, will remove in 1.12.0")
+@deprecated("Use getConfigFormatOptions", "Since 1.12.0, will remove in 1.14.0")
 case class FormattingOptions(
     keepOriginOrder: Boolean = false,
     doubleIndent: Boolean = true,
@@ -56,12 +72,12 @@ case class FormattingOptions(
 )
 
 final class ConfigRenderOptions private (
-    _originComments: Boolean,
-    _comments: Boolean,
-    _formatted: Boolean,
-    _json: Boolean,
-    _showEnvVariableValues: Boolean,
-    _configFormatOptions: ConfigFormatOptions
+    private val _originComments: Boolean,
+    private val _comments: Boolean,
+    private val _formatted: Boolean,
+    private val _json: Boolean,
+    private val _showEnvVariableValues: Boolean,
+    private val _configFormatOptions: ConfigFormatOptions
 ) {
 
   /**
@@ -80,7 +96,7 @@ final class ConfigRenderOptions private (
       new ConfigRenderOptions(
         _originComments,
         value,
-        formatted,
+        _formatted,
         _json,
         _showEnvVariableValues,
         _configFormatOptions
@@ -168,6 +184,7 @@ final class ConfigRenderOptions private (
    *   the new ConfigFormatOptions object
    * @return
    *   the new ConfigRenderOptions object with the new formatting setting
+   * @since 1.12.0
    */
   def setConfigFormatOptions(value: ConfigFormatOptions): ConfigRenderOptions =
     if (value == _configFormatOptions) this
@@ -186,36 +203,37 @@ final class ConfigRenderOptions private (
    *
    * @return
    *   the config format option
+   * @since 1.12.0
    */
   def getConfigFormatOptions: ConfigFormatOptions = _configFormatOptions
 
   @deprecated(
     "Use getOriginComments",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def originComments = _originComments
 
   @deprecated(
     "Use getComments",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
-  def comments = _originComments
+  def comments = _comments
 
   @deprecated(
     "Use getFormatted",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def formatted = _formatted
 
   @deprecated(
     "Use getJson",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def json = _json
 
   @deprecated(
     "Use getShowEnvVariableValues",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def showEnvVariableValues = _showEnvVariableValues
 
@@ -230,7 +248,7 @@ final class ConfigRenderOptions private (
    */
   @deprecated(
     "Use setConfigFormatOptions",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
     if (value == convert(_configFormatOptions)) this
@@ -261,13 +279,13 @@ final class ConfigRenderOptions private (
 
   @deprecated(
     "Use getConfigFormatOptions",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def formattingOptions: FormattingOptions = convert(_configFormatOptions)
 
   @deprecated(
     "Use getConfigFormatOptions",
-    "Since 1.10.0, will remove in 1.12.0"
+    "Since 1.12.0, will remove in 1.14.0"
   )
   def getFormattingOptions: FormattingOptions = convert(_configFormatOptions)
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -17,8 +17,8 @@ object ConfigRenderOptions {
 
   /**
    * Returns the default render options which are verbose (commented and
-   * formatted). See [[ConfigRenderOptions#concise]] for stripped-down options.
-   * This rendering will not be valid JSON since it has comments.
+   * formatted). See [[ConfigRenderOptions$.concise*]] for stripped-down
+   * options. This rendering will not be valid JSON since it has comments.
    *
    * @return
    *   the default render options
@@ -28,7 +28,7 @@ object ConfigRenderOptions {
    *   - formatted = true
    *   - json = true
    *   - showEnvVariableValues = true
-   *   - configFormatOptions = [[ConfigFormatOptions#default]]
+   *   - configFormatOptions = [[ConfigFormatOptions$.default*]]
    */
   def defaults = new ConfigRenderOptions(
     true,
@@ -51,7 +51,7 @@ object ConfigRenderOptions {
    *   - formatted = false
    *   - json = true
    *   - showEnvVariableValues = true
-   *   - configFormatOptions = [[ConfigFormatOptions#default]]
+   *   - configFormatOptions = [[ConfigFormatOptions$.default*]]
    */
   def concise = new ConfigRenderOptions(
     false,

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigRenderOptions.scala
@@ -56,12 +56,12 @@ case class FormattingOptions(
 )
 
 final class ConfigRenderOptions private (
-    private val originComments: Boolean,
-    comments: Boolean,
-    formatted: Boolean,
-    json: Boolean,
-    showEnvVariableValues: Boolean,
-    configFormatOptions: ConfigFormatOptions
+    _originComments: Boolean,
+    _comments: Boolean,
+    _formatted: Boolean,
+    _json: Boolean,
+    _showEnvVariableValues: Boolean,
+    _configFormatOptions: ConfigFormatOptions
 ) {
 
   /**
@@ -75,15 +75,15 @@ final class ConfigRenderOptions private (
    *   options with requested setting for comments
    */
   def setComments(value: Boolean): ConfigRenderOptions =
-    if (value == comments) this
+    if (value == _comments) this
     else
       new ConfigRenderOptions(
-        originComments,
+        _originComments,
         value,
         formatted,
-        json,
-        showEnvVariableValues,
-        configFormatOptions
+        _json,
+        _showEnvVariableValues,
+        _configFormatOptions
       )
 
   /**
@@ -93,7 +93,7 @@ final class ConfigRenderOptions private (
    * @return
    *   true if comments should be rendered
    */
-  def getComments: Boolean = comments
+  def getComments: Boolean = _comments
 
   /**
    * Returns options with origin comments toggled. If this is enabled, the
@@ -111,15 +111,15 @@ final class ConfigRenderOptions private (
    *   options with origin comments toggled
    */
   def setOriginComments(value: Boolean): ConfigRenderOptions =
-    if (value == originComments) this
+    if (value == _originComments) this
     else
       new ConfigRenderOptions(
         value,
-        comments,
-        formatted,
-        json,
-        showEnvVariableValues,
-        configFormatOptions
+        _comments,
+        _formatted,
+        _json,
+        _showEnvVariableValues,
+        _configFormatOptions
       )
 
   /**
@@ -129,7 +129,7 @@ final class ConfigRenderOptions private (
    * @return
    *   true if origin comments should be rendered
    */
-  def getOriginComments: Boolean = originComments
+  def getOriginComments: Boolean = _originComments
 
   /**
    * Returns options with formatting toggled. Formatting means indentation and
@@ -141,15 +141,15 @@ final class ConfigRenderOptions private (
    *   options with requested setting for formatting
    */
   def setFormatted(value: Boolean): ConfigRenderOptions =
-    if (value == formatted) this
+    if (value == _formatted) this
     else
       new ConfigRenderOptions(
-        originComments,
-        comments,
+        _originComments,
+        _comments,
         value,
-        json,
-        showEnvVariableValues,
-        configFormatOptions
+        _json,
+        _showEnvVariableValues,
+        _configFormatOptions
       )
 
   /**
@@ -159,7 +159,7 @@ final class ConfigRenderOptions private (
    * @return
    *   true if the options enable formatting
    */
-  def getFormatted: Boolean = formatted
+  def getFormatted: Boolean = _formatted
 
   /**
    * Set the config format options. Formatting is dependant on formatted flag.
@@ -170,14 +170,14 @@ final class ConfigRenderOptions private (
    *   the new ConfigRenderOptions object with the new formatting setting
    */
   def setConfigFormatOptions(value: ConfigFormatOptions): ConfigRenderOptions =
-    if (value == configFormatOptions) this
+    if (value == _configFormatOptions) this
     else
       new ConfigRenderOptions(
-        originComments,
-        comments,
-        formatted,
-        json,
-        showEnvVariableValues,
+        _originComments,
+        _comments,
+        _formatted,
+        _json,
+        _showEnvVariableValues,
         value
       )
 
@@ -187,7 +187,37 @@ final class ConfigRenderOptions private (
    * @return
    *   the config format option
    */
-  def getConfigFormatOptions: ConfigFormatOptions = configFormatOptions
+  def getConfigFormatOptions: ConfigFormatOptions = _configFormatOptions
+
+  @deprecated(
+    "Use getOriginComments",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def originComments = _originComments
+
+  @deprecated(
+    "Use getComments",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def comments = _originComments
+
+  @deprecated(
+    "Use getFormatted",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def formatted = _formatted
+
+  @deprecated(
+    "Use getJson",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def json = _json
+
+  @deprecated(
+    "Use getShowEnvVariableValues",
+    "Since 1.10.0, will remove in 1.12.0"
+  )
+  def showEnvVariableValues = _showEnvVariableValues
 
   /**
    * Returns new render options with formatting options set. Formatting is
@@ -203,14 +233,14 @@ final class ConfigRenderOptions private (
     "Since 1.10.0, will remove in 1.12.0"
   )
   def setFormattingOptions(value: FormattingOptions): ConfigRenderOptions =
-    if (value == convert(configFormatOptions)) this
+    if (value == convert(_configFormatOptions)) this
     else
       new ConfigRenderOptions(
-        originComments,
-        comments,
-        formatted,
-        json,
-        showEnvVariableValues,
+        _originComments,
+        _comments,
+        _formatted,
+        _json,
+        _showEnvVariableValues,
         convert(value)
       )
 
@@ -233,13 +263,13 @@ final class ConfigRenderOptions private (
     "Use getConfigFormatOptions",
     "Since 1.10.0, will remove in 1.12.0"
   )
-  def formattingOptions: FormattingOptions = convert(configFormatOptions)
+  def formattingOptions: FormattingOptions = convert(_configFormatOptions)
 
   @deprecated(
     "Use getConfigFormatOptions",
     "Since 1.10.0, will remove in 1.12.0"
   )
-  def getFormattingOptions: FormattingOptions = convert(configFormatOptions)
+  def getFormattingOptions: FormattingOptions = convert(_configFormatOptions)
 
   /**
    * Returns options with JSON toggled. JSON means that HOCON extensions
@@ -254,15 +284,15 @@ final class ConfigRenderOptions private (
    *   options with requested setting for JSON
    */
   def setJson(value: Boolean): ConfigRenderOptions =
-    if (value == json) this
+    if (value == _json) this
     else
       new ConfigRenderOptions(
-        originComments,
-        comments,
-        formatted,
+        _originComments,
+        _comments,
+        _formatted,
         value,
-        showEnvVariableValues,
-        configFormatOptions
+        _showEnvVariableValues,
+        _configFormatOptions
       )
 
   /**
@@ -272,7 +302,7 @@ final class ConfigRenderOptions private (
    * @return
    *   true if only JSON should be rendered
    */
-  def getJson: Boolean = json
+  def getJson: Boolean = _json
 
   /**
    * Returns options with showEnvVariableValues toggled. This controls if values
@@ -284,15 +314,15 @@ final class ConfigRenderOptions private (
    *   options with requested setting for environment variables
    */
   def setShowEnvVariableValues(value: Boolean): ConfigRenderOptions =
-    if (value == showEnvVariableValues) this
+    if (value == _showEnvVariableValues) this
     else
       new ConfigRenderOptions(
-        originComments,
-        comments,
-        formatted,
-        json,
+        _originComments,
+        _comments,
+        _formatted,
+        _json,
         value,
-        configFormatOptions
+        _configFormatOptions
       )
 
   /**
@@ -303,23 +333,23 @@ final class ConfigRenderOptions private (
    * @return
    *   true if environment variable values should be rendered
    */
-  def getShowEnvVariableValues: Boolean = showEnvVariableValues
+  def getShowEnvVariableValues: Boolean = _showEnvVariableValues
 
   override def toString: String = {
     val sb = new StringBuilder("ConfigRenderOptions(")
-    if (originComments) sb.append("originComments,")
-    if (comments) sb.append("comments,")
-    if (formatted) {
+    if (_originComments) sb.append("originComments,")
+    if (_comments) sb.append("comments,")
+    if (_formatted) {
       sb.append("formatted,")
-      if (configFormatOptions.getKeepOriginOrder) sb.append("keepOriginOrder,")
-      if (configFormatOptions.getDoubleIndent) sb.append("doubleIndent,")
-      if (configFormatOptions.getColonAssign) sb.append("colonAssign,")
-      if (configFormatOptions.getNewLineAtEnd) sb.append("newLineAtEnd,")
-      if (configFormatOptions.getSimplifyOneEntryNestedObjects)
+      if (_configFormatOptions.getKeepOriginOrder) sb.append("keepOriginOrder,")
+      if (_configFormatOptions.getDoubleIndent) sb.append("doubleIndent,")
+      if (_configFormatOptions.getColonAssign) sb.append("colonAssign,")
+      if (_configFormatOptions.getNewLineAtEnd) sb.append("newLineAtEnd,")
+      if (_configFormatOptions.getSimplifyOneEntryNestedObjects)
         sb.append("simplifyOneEntryNestedObjects,")
     }
-    if (json) sb.append("json,")
-    if (showEnvVariableValues) sb.append("showEnvVariableValues,")
+    if (_json) sb.append("json,")
+    if (_showEnvVariableValues) sb.append("showEnvVariableValues,")
     val lastIndex = sb.length - 1
     if (sb.charAt(lastIndex) == ',')
       sb.setCharAt(lastIndex, ')')

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
@@ -83,7 +83,9 @@ object AbstractConfigValue {
     if (options.getFormatted) {
       var remaining = indent
       while (remaining > 0) {
-        sb.append(if (options.formattingOptions.doubleIndent) "    " else "  ")
+        sb.append(
+          if (options.getConfigFormatOptions.getDoubleIndent) "    " else "  "
+        )
         remaining -= 1
       }
     }
@@ -362,9 +364,9 @@ abstract class AbstractConfigValue private[impl] (val _origin: ConfigOrigin)
       } else {
         sb.append(
           if (options.getFormatted) {
-            if (options.formattingOptions.colonAssign) ": " else " = "
+            if (options.getConfigFormatOptions.getColonAssign) ": " else " = "
           } else {
-            if (options.formattingOptions.colonAssign) ":" else "="
+            if (options.getConfigFormatOptions.getColonAssign) ":" else "="
           }
         )
       }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -522,7 +522,7 @@ final class SimpleConfigObject(
   private def trySimplifyTheOnlyNestedObject(
       options: ConfigRenderOptions
   ): Option[(String, AbstractConfigValue)] =
-    if (!options.formattingOptions.simplifyOneEntryNestedObjects || options.getJson) {
+    if (!options.getConfigFormatOptions.getSimplifyOneEntryNestedObjects || options.getJson) {
       None
     } else trySimplifyTheOnlyNestedObjectRec("")
 
@@ -549,7 +549,7 @@ final class SimpleConfigObject(
           renderValueAsMultiLineObject(sb, indentVal, atRoot, options)
       }
     }
-    if (atRoot && options.getFormatted && options.getFormattingOptions.newLineAtEnd)
+    if (atRoot && options.getFormatted && options.getConfigFormatOptions.getNewLineAtEnd)
       sb.append('\n')
   }
 
@@ -571,7 +571,7 @@ final class SimpleConfigObject(
     val keys = new ju.ArrayList[String]
     keys.addAll(keySet)
     val ordering =
-      if (options.formattingOptions.keepOriginOrder)
+      if (options.getConfigFormatOptions.getKeepOriginOrder)
         new SimpleConfigObject.KeepOriginRenderComparator(str =>
           value.get(str).origin
         )

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -522,7 +522,7 @@ final class SimpleConfigObject(
   private def trySimplifyTheOnlyNestedObject(
       options: ConfigRenderOptions
   ): Option[(String, AbstractConfigValue)] =
-    if (!options.getConfigFormatOptions.getSimplifyOneEntryNestedObjects || options.getJson) {
+    if (!options.getConfigFormatOptions.getSimplifyNestedObjects || options.getJson) {
       None
     } else trySimplifyTheOnlyNestedObjectRec("")
 

--- a/sconfig/shared/src/test/scala/junit/Rendering.scala
+++ b/sconfig/shared/src/test/scala/junit/Rendering.scala
@@ -25,7 +25,7 @@ object RenderExample extends App {
     .setDoubleIndent(doubleIndent)
     .setColonAssign(colonAssign)
     .setNewLineAtEnd(newLineAtEnd)
-    .setSimplifyOneEntryNestedObjects(simplifyOneEntryNestedObjects)
+    .setSimplifyNestedObjects(simplifyOneEntryNestedObjects)
 
   val options = ConfigRenderOptions.defaults
     .setFormatted(formatted)

--- a/sconfig/shared/src/test/scala/junit/Rendering.scala
+++ b/sconfig/shared/src/test/scala/junit/Rendering.scala
@@ -1,6 +1,10 @@
 package foo
 
-import org.ekrich.config.{ConfigFactory, ConfigRenderOptions, FormattingOptions}
+import org.ekrich.config.{
+  ConfigFactory,
+  ConfigRenderOptions,
+  ConfigFormatOptions
+}
 
 object RenderExample extends App {
   val formatted = args.contains("--formatted")
@@ -13,12 +17,15 @@ object RenderExample extends App {
   val doubleIndent = !args.contains("--single-indent")
   val colonAssign = args.contains("--colon-assign")
   val newLineAtEnd = !args.contains("--no-new-line-eof")
-  val formattingOptions = FormattingOptions(
-    keepOriginOrder,
-    doubleIndent,
-    colonAssign,
-    newLineAtEnd
-  )
+  val simplifyOneEntryNestedObjects =
+    !args.contains("--simplify-one-entry-nested-objects")
+
+  val configFormatOptions = ConfigFormatOptions.defaults
+    .setKeepOriginOrder(keepOriginOrder)
+    .setDoubleIndent(doubleIndent)
+    .setColonAssign(colonAssign)
+    .setNewLineAtEnd(newLineAtEnd)
+    .setSimplifyOneEntryNestedObjects(simplifyOneEntryNestedObjects)
 
   val options = ConfigRenderOptions.defaults
     .setFormatted(formatted)
@@ -26,7 +33,7 @@ object RenderExample extends App {
     .setComments(comments)
     .setJson(!hocon)
     .setShowEnvVariableValues(!hideEnvVariableValues)
-    .setFormattingOptions(formattingOptions)
+    .setConfigFormatOptions(configFormatOptions)
 
   def render(what: String): Unit = {
     val conf = ConfigFactory

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
@@ -172,7 +172,7 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
   @Test
   def dontSimplifyOneEntryNestedObjects(): Unit = {
     implicit val configFormatOptions =
-      defaultFormatOptions.setSimplifyOneEntryNestedObjects(false)
+      defaultFormatOptions.setSimplifyNestedObjects(false)
 
     val in = """r.p.d= 42"""
     val result = formatHocon(in)
@@ -190,7 +190,7 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
   @Test
   def simplifyOneEntryNestedObjectsOnRoot(): Unit = {
     implicit val configFormatOptions =
-      defaultFormatOptions.setSimplifyOneEntryNestedObjects(true)
+      defaultFormatOptions.setSimplifyNestedObjects(true)
 
     val in = """r { "p.at" { d= 42 } }"""
     val result = formatHocon(in)
@@ -204,7 +204,7 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
   @Test
   def simplifyOneEntryNestedObjectsNotOnRoot(): Unit = {
     implicit val configFormatOptions =
-      defaultFormatOptions.setSimplifyOneEntryNestedObjects(true)
+      defaultFormatOptions.setSimplifyNestedObjects(true)
 
     val in =
       """r { p { "d.ap" { s= 42 } }

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
@@ -105,7 +105,8 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
 
   @Test
   def useFourSpacesIndentation(): Unit = {
-    implicit val configFormatOptions = defaultFormatOptions.setDoubleIndent(true)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setDoubleIndent(true)
 
     val in = """r {
                |  p {
@@ -149,7 +150,8 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
 
   @Test
   def useEqualsAsAssignSign(): Unit = {
-    implicit val configFormatOptions = defaultFormatOptions.setColonAssign(false)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setColonAssign(false)
 
     val in = """r {
                |    s=t_f

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
@@ -5,28 +5,32 @@ import org.ekrich.config.{
   ConfigFactory,
   ConfigParseOptions,
   ConfigRenderOptions,
-  FormattingOptions
+  ConfigFormatOptions
 }
 
-class FormattingOptionsTest extends TestUtilsShared {
+class ConfigFormatOptionsTest extends TestUtilsShared {
   val parseOptions = ConfigParseOptions.defaults.setAllowMissing(true)
   val myDefaultRenderOptions = ConfigRenderOptions.defaults
     .setJson(false)
     .setOriginComments(false)
     .setComments(true)
     .setFormatted(true)
+  val defaultFormatOptions = ConfigFormatOptions.defaults
 
   def formatHocon(
       str: String
-  )(implicit formattingOptions: FormattingOptions): String =
+  )(implicit configFormatOptions: ConfigFormatOptions): String =
     ConfigFactory
       .parseString(str, parseOptions)
       .root
-      .render(myDefaultRenderOptions.setFormattingOptions(formattingOptions))
+      .render(
+        myDefaultRenderOptions.setConfigFormatOptions(configFormatOptions)
+      )
 
   @Test
   def noNewLineAtTheEnd(): Unit = {
-    implicit val formattingOptions = FormattingOptions(newLineAtEnd = false)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setNewLineAtEnd(false)
     val in = """r {
                |}""".stripMargin
     val result = formatHocon(in)
@@ -36,7 +40,7 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def newLineAtTheEnd(): Unit = {
-    implicit val formattingOptions = FormattingOptions()
+    implicit val configFormatOptions = defaultFormatOptions
     val in = """r {
                |}""".stripMargin
     val result = formatHocon(in)
@@ -47,7 +51,8 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def keepOriginOrderOfEntries(): Unit = {
-    implicit val formattingOptions = FormattingOptions(keepOriginOrder = true)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setKeepOriginOrder(true)
 
     val in = """r {
                |  p {
@@ -75,7 +80,8 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def useTwoSpacesIndentation(): Unit = {
-    implicit val formattingOptions = FormattingOptions(doubleIndent = false)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setDoubleIndent(false)
 
     val in = """r {
                |  p {
@@ -99,7 +105,7 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def useFourSpacesIndentation(): Unit = {
-    implicit val formattingOptions = FormattingOptions(doubleIndent = true)
+    implicit val configFormatOptions = defaultFormatOptions.setDoubleIndent(true)
 
     val in = """r {
                |  p {
@@ -123,7 +129,7 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def useColonAsAssignSign(): Unit = {
-    implicit val formattingOptions = FormattingOptions(colonAssign = true)
+    implicit val configFormatOptions = defaultFormatOptions.setColonAssign(true)
 
     val in = """r {
                |    s=t_f
@@ -143,7 +149,7 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def useEqualsAsAssignSign(): Unit = {
-    implicit val formattingOptions = FormattingOptions(colonAssign = false)
+    implicit val configFormatOptions = defaultFormatOptions.setColonAssign(false)
 
     val in = """r {
                |    s=t_f
@@ -163,8 +169,8 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def dontSimplifyOneEntryNestedObjects(): Unit = {
-    implicit val formattingOptions =
-      FormattingOptions(simplifyOneEntryNestedObjects = false)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setSimplifyOneEntryNestedObjects(false)
 
     val in = """r.p.d= 42"""
     val result = formatHocon(in)
@@ -181,8 +187,8 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def simplifyOneEntryNestedObjectsOnRoot(): Unit = {
-    implicit val formattingOptions =
-      FormattingOptions(simplifyOneEntryNestedObjects = true)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setSimplifyOneEntryNestedObjects(true)
 
     val in = """r { "p.at" { d= 42 } }"""
     val result = formatHocon(in)
@@ -195,8 +201,8 @@ class FormattingOptionsTest extends TestUtilsShared {
 
   @Test
   def simplifyOneEntryNestedObjectsNotOnRoot(): Unit = {
-    implicit val formattingOptions =
-      FormattingOptions(simplifyOneEntryNestedObjects = true)
+    implicit val configFormatOptions =
+      defaultFormatOptions.setSimplifyOneEntryNestedObjects(true)
 
     val in =
       """r { p { "d.ap" { s= 42 } }


### PR DESCRIPTION
The fields from `ConfigRenderOptions`, `ConfigParseOptions`, and `ConfigMemorySize` have leaked due to porting error. `val field: Type` vs `field: Type`

These are long term problems. The formatting MIMA problems have been fixed via renaming and delegation with deprecation.