### PR TITLE
Remove Scala Collection Compat dependency from library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val sconfig = crossProject(JVMPlatform, NativePlatform, JSPlatform)
       if (isScala3.value) dotcOpts else scalacOpts
     },
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %%% "scala-collection-compat" % scCompat,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % scCompat % Test,
       "org.json4s" %%% "json4s-native-core" % json4s % Test
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v"),

--- a/sconfig/jvm-native/src/test/scala/org/ekrich/config/impl/FileUtils.scala
+++ b/sconfig/jvm-native/src/test/scala/org/ekrich/config/impl/FileUtils.scala
@@ -57,13 +57,15 @@ object FileUtils {
     writer.close()
   }
 
+  // TODO: should make this tail recursive
   def deleteRecursive(f: File): Unit = {
     if (f.exists) {
       if (f.isDirectory) {
         val children = f.listFiles()
         if (children ne null) {
-          for (c <- children)
+          children.foreach { c =>
             deleteRecursive(c)
+          }
         }
       }
       f.delete()

--- a/sconfig/jvm/src/main/scala/org/ekrich/config/impl/ConfigBeanImpl.scala
+++ b/sconfig/jvm/src/main/scala/org/ekrich/config/impl/ConfigBeanImpl.scala
@@ -12,7 +12,6 @@ import java.lang.reflect.Type
 import java.{util => ju}
 import java.{lang => jl}
 import java.time.Duration
-import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import scala.util.Try
 import org.ekrich.config.Config
@@ -54,7 +53,7 @@ object ConfigBeanImpl {
     val configProps =
       new ju.HashMap[String, AbstractConfigValue]
     val originalNames = new ju.HashMap[String, String]
-    for (configProp <- config.root.entrySet.asScala) {
+    config.root.entrySet.forEach { configProp =>
       val originalName = configProp.getKey
       val camelName = ConfigImplUtil.toCamelCase(originalName)
       // if a setting is in there both as some hyphen name and the camel name,
@@ -83,7 +82,7 @@ object ConfigBeanImpl {
     try {
       val beanProps =
         new ju.ArrayList[PropertyDescriptor]
-      for (beanProp <- beanInfo.getPropertyDescriptors) {
+      beanInfo.getPropertyDescriptors.foreach { beanProp =>
         breakable {
           if (beanProp.getReadMethod == null || beanProp.getWriteMethod == null)
             break() // continue
@@ -93,7 +92,7 @@ object ConfigBeanImpl {
       // Try to throw all validation issues at once (this does not comprehensively
       // find every issue, but it should find common ones).
       val problems = new ju.ArrayList[ConfigException.ValidationProblem]
-      for (beanProp <- beanProps.asScala) {
+      beanProps.forEach { beanProp =>
         val setter: Method = beanProp.getWriteMethod
         val parameterClass: Class[_] = setter.getParameterTypes()(0)
         val expectedType = getValueTypeOrNull(parameterClass)
@@ -113,7 +112,7 @@ object ConfigBeanImpl {
         throw new ConfigException.ValidationFailed(problems)
       // Fill in the bean instance
       val bean = clazz.getDeclaredConstructor().newInstance()
-      for (beanProp <- beanProps.asScala) {
+      beanProps.forEach { beanProp =>
         breakable {
           val setter = beanProp.getWriteMethod
           val parameterType = setter.getGenericParameterTypes()(0)
@@ -302,7 +301,7 @@ object ConfigBeanImpl {
       val beanList = new ju.ArrayList[AnyRef]
       val configList: ju.List[_ <: Config] =
         config.getConfigList(configPropName)
-      for (listMember <- configList.asScala) {
+      configList.forEach { listMember =>
         beanList.add(createInternal(listMember, getTypeAsClass(elementType)))
       }
       beanList

--- a/sconfig/shared/src/main/scala-2/org/ekrich/config/impl/MemoryUnit.scala
+++ b/sconfig/shared/src/main/scala-2/org/ekrich/config/impl/MemoryUnit.scala
@@ -65,7 +65,7 @@ private object MemoryUnit {
 
   lazy val unitsMap: ju.Map[String, MemoryUnit] = {
     val map = new ju.HashMap[String, MemoryUnit]
-    for (unit <- MemoryUnit.values()) {
+    MemoryUnit.values().foreach { unit =>
       map.put(unit.prefix + "byte", unit)
       map.put(unit.prefix + "bytes", unit)
       if (unit.prefix.length == 0) {

--- a/sconfig/shared/src/main/scala-2/org/ekrich/config/impl/ResolveStatus.scala
+++ b/sconfig/shared/src/main/scala-2/org/ekrich/config/impl/ResolveStatus.scala
@@ -2,6 +2,7 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
+import ScalaOps.*
 
 /**
  * Status of substitution resolution.
@@ -25,13 +26,10 @@ object ResolveStatus {
 
   def fromValues(
       values: ju.Collection[_ <: AbstractConfigValue]
-  ): ResolveStatus = {
-    import scala.jdk.CollectionConverters._
-    values.asScala.find(_.resolveStatus == ResolveStatus.UNRESOLVED) match {
-      case Some(_) => ResolveStatus.UNRESOLVED
-      case None    => ResolveStatus.RESOLVED
-    }
-  }
+  ): ResolveStatus =
+    values.scalaOps.findFold(_.resolveStatus == ResolveStatus.UNRESOLVED)(() =>
+      ResolveStatus.RESOLVED /* default not found */
+    )(_ => ResolveStatus.UNRESOLVED)
 
   def fromBoolean(resolved: Boolean): ResolveStatus =
     if (resolved) ResolveStatus.RESOLVED else ResolveStatus.UNRESOLVED

--- a/sconfig/shared/src/main/scala-3/org/ekrich/config/impl/MemoryUnit.scala
+++ b/sconfig/shared/src/main/scala-3/org/ekrich/config/impl/MemoryUnit.scala
@@ -33,7 +33,7 @@ private object MemoryUnit {
 
   private lazy val unitsMap: ju.Map[String, MemoryUnit] = {
     val map = new ju.HashMap[String, MemoryUnit]
-    for (unit <- MemoryUnit.values) {
+    MemoryUnit.values.foreach { unit =>
       map.put(unit.prefix + "byte", unit)
       map.put(unit.prefix + "bytes", unit)
       if (unit.prefix.length == 0) {

--- a/sconfig/shared/src/main/scala-3/org/ekrich/config/impl/ResolveStatus.scala
+++ b/sconfig/shared/src/main/scala-3/org/ekrich/config/impl/ResolveStatus.scala
@@ -2,6 +2,7 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
+import ScalaOps.*
 
 /**
  * Status of substitution resolution.
@@ -13,13 +14,10 @@ enum ResolveStatus extends jl.Enum[ResolveStatus] {
 object ResolveStatus {
   def fromValues(
       values: ju.Collection[_ <: AbstractConfigValue]
-  ): ResolveStatus = {
-    import scala.jdk.CollectionConverters._
-    values.asScala.find(_.resolveStatus == ResolveStatus.UNRESOLVED) match {
-      case Some(_) => ResolveStatus.UNRESOLVED
-      case None    => ResolveStatus.RESOLVED
-    }
-  }
+  ): ResolveStatus =
+    values.scalaOps.findFold(_.resolveStatus == ResolveStatus.UNRESOLVED)(() =>
+      ResolveStatus.RESOLVED /* default not found */
+    )(_ => ResolveStatus.UNRESOLVED)
 
   def fromBoolean(resolved: Boolean): ResolveStatus =
     if (resolved) ResolveStatus.RESOLVED else ResolveStatus.UNRESOLVED

--- a/sconfig/shared/src/main/scala/org/ekrich/config/ConfigException.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/ConfigException.scala
@@ -351,8 +351,7 @@ object ConfigException {
         problems: jl.Iterable[ConfigException.ValidationProblem]
     ): String = {
       val sb = new StringBuilder
-      import scala.jdk.CollectionConverters._
-      for (p <- problems.asScala) {
+      problems.forEach { p =>
         sb.append(p.origin.description)
         sb.append(": ")
         sb.append(p.path)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigNode.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigNode.scala
@@ -11,8 +11,7 @@ abstract class AbstractConfigNode extends ConfigNode {
 
   override final def render: String = {
     val origText = new StringBuilder
-    import scala.jdk.CollectionConverters._
-    for (t <- tokens.asScala) {
+    tokens.forEach { t =>
       origText.append(t.tokenText)
     }
     origText.toString

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
@@ -6,7 +6,6 @@ package org.ekrich.config.impl
 import java.{lang => jl}
 import java.{util => ju}
 import scala.annotation.varargs
-import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigMergeable
 import org.ekrich.config.ConfigObject
@@ -14,7 +13,6 @@ import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions
 import org.ekrich.config.ConfigValue
 import org.ekrich.config.ConfigValueType
-
 
 object AbstractConfigObject {
   private def peekPath(
@@ -36,7 +34,7 @@ object AbstractConfigObject {
     }
 
   private[impl] def mergeOrigins(
-      stack: ju.Collection[_ <: AbstractConfigValue]
+      stack: ju.Collection[? <: AbstractConfigValue]
   ): ConfigOrigin = {
     if (stack.isEmpty)
       throw new ConfigException.BugOrBroken("can't merge origins on empty list")
@@ -66,11 +64,7 @@ object AbstractConfigObject {
 
   @varargs private[impl] def mergeOrigins(
       stack: AbstractConfigObject*
-  ): ConfigOrigin = {
-    val javaColl = stack.asJavaCollection
-    mergeOrigins(javaColl)
-    // throws NotPossibleToResolve
-  }
+  ): ConfigOrigin = mergeOrigins(ju.Arrays.asList(stack.toArray: _*))
 
   private def weAreImmutable(method: String) =
     new UnsupportedOperationException(

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
@@ -5,7 +5,8 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
-
+import scala.annotation.varargs
+import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigMergeable
 import org.ekrich.config.ConfigObject
@@ -14,8 +15,6 @@ import org.ekrich.config.ConfigRenderOptions
 import org.ekrich.config.ConfigValue
 import org.ekrich.config.ConfigValueType
 
-import scala.annotation.varargs
-import scala.jdk.CollectionConverters._
 
 object AbstractConfigObject {
   private def peekPath(

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigObject.scala
@@ -44,7 +44,7 @@ object AbstractConfigObject {
     val origins = new ju.ArrayList[ConfigOrigin]
     var firstOrigin: ConfigOrigin = null
     var numMerged = 0
-    for (v <- stack.asScala) {
+    stack.forEach { v =>
       if (firstOrigin == null) firstOrigin = v.origin
       if (v.isInstanceOf[AbstractConfigObject] && (v
             .asInstanceOf[AbstractConfigObject]

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/AbstractConfigValue.scala
@@ -6,9 +6,6 @@ package org.ekrich.config.impl
 import java.{lang => jl}
 import java.{util => ju}
 import ju.Collections
-
-import scala.jdk.CollectionConverters._
-
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigMergeable
 import org.ekrich.config.ConfigObject
@@ -16,6 +13,7 @@ import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions
 import org.ekrich.config.ConfigValue
 import org.ekrich.config.impl.AbstractConfigValue.NotPossibleToResolve
+import ScalaOps._
 
 /**
  * Trying very hard to avoid a parent reference in config values; when you have
@@ -66,9 +64,9 @@ object AbstractConfigValue {
       list: ju.List[AbstractConfigValue],
       descendant: AbstractConfigValue
   ): Boolean =
-    list.asScala.exists(_ == descendant) ||
+    list.scalaOps.exists(_ == descendant) ||
       // now the expensive traversal
-      list.asScala.exists(
+      list.scalaOps.exists(
         _ match {
           case v: Container => v.hasDescendant(descendant)
           case _            => false

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/BadMap.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/BadMap.scala
@@ -1,4 +1,5 @@
 package org.ekrich.config.impl
+
 import scala.annotation.tailrec
 
 /**
@@ -40,13 +41,7 @@ object BadMap {
     }
   }
   private def rehash(src: Array[Entry], dest: Array[BadMap.Entry]): Unit = {
-    //        for (entry <- src) {
     // have to store each "next" element individually; they may belong in different indices
-    //            while ({ entry != null }) {
-    //                store(dest, entry)
-    //                entry = entry.next
-    //            }
-    //        }
     @tailrec
     def processEntry(entry: Entry): Unit = {
       if (entry != null) {
@@ -55,7 +50,7 @@ object BadMap {
       }
     }
 
-    for (entry <- src) {
+    src.foreach { entry =>
       processEntry(entry)
     }
   }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
@@ -91,14 +91,14 @@ object ConfigConcatenation {
     else {
       val flattened =
         new ju.ArrayList[AbstractConfigValue](pieces.size)
-      for (v <- pieces.asScala) {
+      pieces.forEach { v =>
         if (v.isInstanceOf[ConfigConcatenation])
           flattened.addAll(v.asInstanceOf[ConfigConcatenation].pieces)
         else flattened.add(v)
       }
       val consolidated =
         new ju.ArrayList[AbstractConfigValue](flattened.size)
-      for (v <- flattened.asScala) {
+      flattened.forEach { v =>
         if (consolidated.isEmpty) consolidated.add(v)
         else join(consolidated, v)
       }
@@ -127,7 +127,7 @@ final class ConfigConcatenation(
       "Created concatenation with less than 2 items: " + this
     )
   var hadUnmergeable = false
-  for (p <- pieces.asScala) {
+  pieces.forEach { p =>
     if (p.isInstanceOf[ConfigConcatenation])
       throw new ConfigException.BugOrBroken(
         "ConfigConcatenation should never be nested: " + this
@@ -173,7 +173,7 @@ final class ConfigConcatenation(
         "concatenation has " + pieces.size + " pieces:"
       )
       var count = 0
-      for (v <- pieces.asScala) {
+      pieces.forEach { v =>
         ConfigImpl.trace(indent, s"$count: $v")
         count += 1
       }
@@ -185,7 +185,8 @@ final class ConfigConcatenation(
     var newContext = context
     val resolved =
       new ju.ArrayList[AbstractConfigValue](pieces.size)
-    for (p <- pieces.asScala) { // to concat into a string we have to do a full resolve,
+    pieces.forEach { p =>
+      // to concat into a string we have to do a full resolve,
       // so unrestrict the context, then put restriction back afterward
       val restriction = newContext.restrictToChild
       val result =
@@ -235,7 +236,7 @@ final class ConfigConcatenation(
   override def relativized(prefix: Path): ConfigConcatenation = {
     val newPieces =
       new ju.ArrayList[AbstractConfigValue]
-    for (p <- pieces.asScala) {
+    pieces.forEach { p =>
       newPieces.add(p.relativized(prefix))
     }
     new ConfigConcatenation(origin, newPieces)
@@ -260,7 +261,7 @@ final class ConfigConcatenation(
       atRoot: Boolean,
       options: ConfigRenderOptions
   ): Unit = {
-    for (p <- pieces.asScala) {
+    pieces.forEach { p =>
       p.renderValue(sb, indent, atRoot, options)
     }
   }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigConcatenation.scala
@@ -2,7 +2,6 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
-import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigObject
 import org.ekrich.config.ConfigOrigin

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMerge.scala
@@ -5,7 +5,6 @@ package org.ekrich.config.impl
 
 import java.{lang => jl}
 import java.{util => ju}
-import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions
@@ -35,7 +34,7 @@ object ConfigDelayedMerge {
         "delayed merge stack has " + stack.size + " items:"
       )
       var count = 0
-      for (v <- stack.asScala) {
+      stack.forEach { v =>
         ConfigImpl.trace(context.depth + 1, s"$count: $v")
         count += 1
       }
@@ -48,7 +47,8 @@ object ConfigDelayedMerge {
     var newContext = context
     var count = 0
     var merged: AbstractConfigValue = null
-    for (end <- stack.asScala) { // the end value may or may not be resolved already
+    // the end value may or may not be resolved already
+    stack.forEach { end =>
       var sourceForEnd: ResolveSource = null
       if (end.isInstanceOf[ReplaceableMergeStack])
         throw new ConfigException.BugOrBroken(
@@ -132,7 +132,7 @@ object ConfigDelayedMerge {
       null
     } else { // generate a new merge stack from only the remaining items
       var merged: AbstractConfigValue = null
-      for (v <- subStack.asScala) {
+      subStack.forEach { v =>
         if (merged == null) merged = v else merged = merged.withFallback(v)
       }
       merged
@@ -170,7 +170,7 @@ object ConfigDelayedMerge {
     reversed.addAll(stack)
     ju.Collections.reverse(reversed)
     var i = 0
-    for (v <- reversed.asScala) {
+    reversed.forEach { v =>
       if (commentMerge) {
         indent(sb, indentVal, options)
         if (atKey != null)
@@ -182,7 +182,7 @@ object ConfigDelayedMerge {
         i += 1
         sb.append(v.origin.description)
         sb.append("\n")
-        for (comment <- v.origin.comments.asScala) {
+        v.origin.comments.forEach { comment =>
           indent(sb, indentVal, options)
           sb.append("# ")
           sb.append(comment)
@@ -220,7 +220,7 @@ final class ConfigDelayedMerge(
   if (stack.isEmpty)
     throw new ConfigException.BugOrBroken("creating empty delayed merge value")
 
-  for (v <- stack.asScala) {
+  stack.forEach { v =>
     if (v.isInstanceOf[ConfigDelayedMerge] ||
         v.isInstanceOf[ConfigDelayedMergeObject])
       throw new ConfigException.BugOrBroken(
@@ -266,7 +266,7 @@ final class ConfigDelayedMerge(
 
   override def relativized(prefix: Path): ConfigDelayedMerge = {
     val newStack = new ju.ArrayList[AbstractConfigValue]
-    for (o <- stack.asScala) {
+    stack.forEach { o =>
       newStack.add(o.relativized(prefix))
     }
     new ConfigDelayedMerge(origin, newStack)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
@@ -37,7 +37,7 @@ final class ConfigDelayedMergeObject(
     throw new ConfigException.BugOrBroken(
       "created a delayed merge object not guaranteed to be an object"
     )
-  stack.asScala.foreach { v =>
+  stack.forEach { v =>
     v match {
       case _: ConfigDelayedMerge | _: ConfigDelayedMergeObject =>
         throw new ConfigException.BugOrBroken(
@@ -85,7 +85,7 @@ final class ConfigDelayedMergeObject(
     AbstractConfigValue.hasDescendantInList(stack, descendant)
   override def relativized(prefix: Path): ConfigDelayedMergeObject = {
     val newStack = new ju.ArrayList[AbstractConfigValue]
-    for (o <- stack.asScala) {
+    stack.forEach { o =>
       newStack.add(o.relativized(prefix))
     }
     new ConfigDelayedMergeObject(origin, newStack)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
@@ -3,11 +3,11 @@
  */
 package org.ekrich.config.impl
 
-import java.{lang => jl}
-import java.{util => ju}
+import java.lang as jl
+import java.util as ju
 
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
+//import scala.jdk.CollectionConverters._
 
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigList
@@ -198,87 +198,86 @@ final class ConfigDelayedMergeObject(
     // fallbacks, prior to any unmergeable values.
     @tailrec
     def loop(
-        layers: List[AbstractConfigValue]
-    ): Either[ConfigException, AbstractConfigValue] =
-      layers match {
-        case Nil =>
-          // If we get here, then we never found anything unresolved which means
-          // the ConfigDelayedMergeObject should not have existed. some
-          // invariant was violated.
-          Left(
-            new ConfigException.BugOrBroken(
-              "Delayed merge stack does not contain any unmergeable values"
-            )
+        layers: ju.List[AbstractConfigValue]
+    ): Either[ConfigException, AbstractConfigValue] = {
+      val head = layers.get(0)
+      val tail = layers.subList(1, layers.size()) // view
+      if (head == null) {
+        // If we get here, then we never found anything unresolved which means
+        // the ConfigDelayedMergeObject should not have existed. some
+        // invariant was violated.
+        Left(
+          new ConfigException.BugOrBroken(
+            "Delayed merge stack does not contain any unmergeable values"
           )
-        case head :: tl =>
-          head match {
-            case layer: AbstractConfigObject => {
-              layer.attemptPeekWithPartialResolve(key) match {
-                case v if v != null =>
-                  if (v.ignoresFallbacks) {
-                    // we know we won't need to merge anything in to this value
-                    Right(v)
-                  } else {
-                    // we can't return this value because we know there are
-                    // unmergeable values later in the stack that may
-                    // contain values that need to be merged with this
-                    // value. we'll throw the exception when we get to those
-                    // unmergeable values, so continue here.
-                    loop(tl)
-                  }
-                case _: Unmergeable =>
-                  // an unmergeable object (which would be another
-                  // ConfigDelayedMergeObject) can't know that a key is
-                  // missing, so it can't return null; it can only return a
-                  // value or throw NotPossibleToResolve
-                  throw new ConfigException.BugOrBroken(
-                    "should not be reached: unmergeable object returned null value"
-                  )
-                case _ =>
-                  // a non-unmergeable AbstractConfigObject that returned null
-                  // for the key in question is not relevant, we can keep
-                  // looking for a value.
-                  loop(tl)
-              }
-            }
-            case _: Unmergeable =>
-              throw new ConfigException.NotResolved(
-                s"Key '$key' is not available at '${origin.description}' because value at '${head.origin.description}'" +
-                  s" has not been resolved and may turn out to contain or hide '$key'." +
-                  " Be sure to Config#resolve() before using a config object."
-              )
-            case layer if (layer.resolveStatus eq ResolveStatus.UNRESOLVED) =>
-              // if the layer is not an object, and not a substitution or merge,
-              // then it's something that's unresolved because it _contains_
-              // an unresolved object... i.e. it's an array
-              layer match {
-                case _: ConfigList =>
-                  // all later objects will be hidden so we can say we won't find
-                  // the key
-                  Right(null)
-                case _ =>
-                  throw new ConfigException.BugOrBroken(
-                    "Expecting a list here, not " + layer
-                  )
-              }
-
-            case _ =>
-              // non-object, but resolved, like an integer or something.
-              // has no children so the one we're after won't be in it.
-              // we would only have this in the stack in case something
-              // else "looks back" to it due to a cycle.
-              // anyway at this point we know we can't find the key anymore.
-              if (head.ignoresFallbacks)
-                Right(null)
-              else {
+        )
+      } else {
+        head match {
+          case layer: AbstractConfigObject =>
+            layer.attemptPeekWithPartialResolve(key) match {
+              case v if v != null =>
+                if (v.ignoresFallbacks) {
+                  // we know we won't need to merge anything in to this value
+                  Right(v)
+                } else {
+                  // we can't return this value because we know there are
+                  // unmergeable values later in the stack that may
+                  // contain values that need to be merged with this
+                  // value. we'll throw the exception when we get to those
+                  // unmergeable values, so continue here.
+                  loop(tail)
+                }
+              case _: Unmergeable =>
+                // an unmergeable object (which would be another
+                // ConfigDelayedMergeObject) can't know that a key is
+                // missing, so it can't return null; it can only return a
+                // value or throw NotPossibleToResolve
                 throw new ConfigException.BugOrBroken(
-                  "resolved non-object should ignore fallbacks"
+                  "should not be reached: unmergeable object returned null value"
                 )
-              }
-          }
+              case _ =>
+                // a non-unmergeable AbstractConfigObject that returned null
+                // for the key in question is not relevant, we can keep
+                // looking for a value.
+                loop(tail)
+            }
+          case _: Unmergeable =>
+            throw new ConfigException.NotResolved(
+              s"Key '$key' is not available at '${origin.description}' because value at '${head.origin.description}'" +
+                s" has not been resolved and may turn out to contain or hide '$key'." +
+                " Be sure to Config#resolve() before using a config object."
+            )
+          case layer if (layer.resolveStatus eq ResolveStatus.UNRESOLVED) =>
+            // if the layer is not an object, and not a substitution or merge,
+            // then it's something that's unresolved because it _contains_
+            // an unresolved object... i.e. it's an array
+            layer match {
+              case _: ConfigList =>
+                // all later objects will be hidden so we can say we won't find
+                // the key
+                Right(null)
+              case _ =>
+                throw new ConfigException.BugOrBroken(
+                  "Expecting a list here, not " + layer
+                )
+            }
+          case _ =>
+            // non-object, but resolved, like an integer or something.
+            // has no children so the one we're after won't be in it.
+            // we would only have this in the stack in case something
+            // else "looks back" to it due to a cycle.
+            // anyway at this point we know we can't find the key anymore.
+            if (head.ignoresFallbacks)
+              Right(null)
+            else
+              throw new ConfigException.BugOrBroken(
+                "resolved non-object should ignore fallbacks"
+              )
+        }
       }
+    }
     // run the logic
-    loop(stack.asScala.toList) match {
+    loop(stack) match {
       case Right(res) =>
         res
       case Left(ex) =>

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDelayedMergeObject.scala
@@ -5,10 +5,7 @@ package org.ekrich.config.impl
 
 import java.lang as jl
 import java.util as ju
-
 import scala.annotation.tailrec
-//import scala.jdk.CollectionConverters._
-
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigList
 import org.ekrich.config.ConfigMergeable
@@ -199,89 +196,80 @@ final class ConfigDelayedMergeObject(
     @tailrec
     def loop(
         layers: ju.List[AbstractConfigValue]
-    ): Either[ConfigException, AbstractConfigValue] = {
+    ): AbstractConfigValue = {
       val head = layers.get(0)
       val tail = layers.subList(1, layers.size()) // view
-      if (head == null) {
-        // If we get here, then we never found anything unresolved which means
-        // the ConfigDelayedMergeObject should not have existed. some
-        // invariant was violated.
-        Left(
-          new ConfigException.BugOrBroken(
+      head match {
+        case null =>
+          // If we get here, then we never found anything unresolved which means
+          // the ConfigDelayedMergeObject should not have existed. some
+          // invariant was violated.
+          throw new ConfigException.BugOrBroken(
             "Delayed merge stack does not contain any unmergeable values"
           )
-        )
-      } else {
-        head match {
-          case layer: AbstractConfigObject =>
-            layer.attemptPeekWithPartialResolve(key) match {
-              case v if v != null =>
-                if (v.ignoresFallbacks) {
-                  // we know we won't need to merge anything in to this value
-                  Right(v)
-                } else {
-                  // we can't return this value because we know there are
-                  // unmergeable values later in the stack that may
-                  // contain values that need to be merged with this
-                  // value. we'll throw the exception when we get to those
-                  // unmergeable values, so continue here.
-                  loop(tail)
-                }
-              case _: Unmergeable =>
-                // an unmergeable object (which would be another
-                // ConfigDelayedMergeObject) can't know that a key is
-                // missing, so it can't return null; it can only return a
-                // value or throw NotPossibleToResolve
-                throw new ConfigException.BugOrBroken(
-                  "should not be reached: unmergeable object returned null value"
-                )
-              case _ =>
-                // a non-unmergeable AbstractConfigObject that returned null
-                // for the key in question is not relevant, we can keep
-                // looking for a value.
+        case layer: AbstractConfigObject =>
+          layer.attemptPeekWithPartialResolve(key) match {
+            case v if v != null =>
+              if (v.ignoresFallbacks) {
+                // we know we won't need to merge anything in to this value
+                v
+              } else {
+                // we can't return this value because we know there are
+                // unmergeable values later in the stack that may
+                // contain values that need to be merged with this
+                // value. we'll throw the exception when we get to those
+                // unmergeable values, so continue here.
                 loop(tail)
-            }
-          case _: Unmergeable =>
-            throw new ConfigException.NotResolved(
-              s"Key '$key' is not available at '${origin.description}' because value at '${head.origin.description}'" +
-                s" has not been resolved and may turn out to contain or hide '$key'." +
-                " Be sure to Config#resolve() before using a config object."
-            )
-          case layer if (layer.resolveStatus eq ResolveStatus.UNRESOLVED) =>
-            // if the layer is not an object, and not a substitution or merge,
-            // then it's something that's unresolved because it _contains_
-            // an unresolved object... i.e. it's an array
-            layer match {
-              case _: ConfigList =>
-                // all later objects will be hidden so we can say we won't find
-                // the key
-                Right(null)
-              case _ =>
-                throw new ConfigException.BugOrBroken(
-                  "Expecting a list here, not " + layer
-                )
-            }
-          case _ =>
-            // non-object, but resolved, like an integer or something.
-            // has no children so the one we're after won't be in it.
-            // we would only have this in the stack in case something
-            // else "looks back" to it due to a cycle.
-            // anyway at this point we know we can't find the key anymore.
-            if (head.ignoresFallbacks)
-              Right(null)
-            else
+              }
+            case _: Unmergeable =>
+              // an unmergeable object (which would be another
+              // ConfigDelayedMergeObject) can't know that a key is
+              // missing, so it can't return null; it can only return a
+              // value or throw NotPossibleToResolve
               throw new ConfigException.BugOrBroken(
-                "resolved non-object should ignore fallbacks"
+                "should not be reached: unmergeable object returned null value"
               )
-        }
+            case _ =>
+              // a non-unmergeable AbstractConfigObject that returned null
+              // for the key in question is not relevant, we can keep
+              // looking for a value.
+              loop(tail)
+          }
+        case _: Unmergeable =>
+          throw new ConfigException.NotResolved(
+            s"Key '$key' is not available at '${origin.description}' because value at '${head.origin.description}'" +
+              s" has not been resolved and may turn out to contain or hide '$key'." +
+              " Be sure to Config#resolve() before using a config object."
+          )
+        case layer if (layer.resolveStatus eq ResolveStatus.UNRESOLVED) =>
+          // if the layer is not an object, and not a substitution or merge,
+          // then it's something that's unresolved because it _contains_
+          // an unresolved object... i.e. it's an array
+          layer match {
+            case _: ConfigList =>
+              // all later objects will be hidden so we can say we won't find
+              // the key
+              null
+            case _ =>
+              throw new ConfigException.BugOrBroken(
+                "Expecting a list here, not " + layer
+              )
+          }
+        case _ =>
+          // non-object, but resolved, like an integer or something.
+          // has no children so the one we're after won't be in it.
+          // we would only have this in the stack in case something
+          // else "looks back" to it due to a cycle.
+          // anyway at this point we know we can't find the key anymore.
+          if (head.ignoresFallbacks)
+            null
+          else
+            throw new ConfigException.BugOrBroken(
+              "resolved non-object should ignore fallbacks"
+            )
       }
     }
     // run the logic
-    loop(stack) match {
-      case Right(res) =>
-        res
-      case Left(ex) =>
-        throw ex
-    }
+    loop(stack)
   }
 }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
@@ -193,8 +193,7 @@ object ConfigDocumentParser {
       // all succeeding tokens
       if (valueCount < 2) {
         var value: AbstractConfigNodeValue = null
-        import scala.jdk.CollectionConverters._
-        for (node <- values.asScala) {
+        values.forEach { node =>
           if (node.isInstanceOf[AbstractConfigNodeValue])
             value = node.asInstanceOf[AbstractConfigNodeValue]
           else if (value == null) nodes.add(node)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
@@ -3,10 +3,9 @@
  */
 package org.ekrich.config.impl
 
-import java.{lang => jl}
-import java.{util => ju}
+import java.lang as jl
+import java.util as ju
 import scala.util.control.Breaks._
-//import scala.collection.mutable
 import org.ekrich.config._
 
 object ConfigDocumentParser {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigDocumentParser.scala
@@ -6,7 +6,7 @@ package org.ekrich.config.impl
 import java.{lang => jl}
 import java.{util => ju}
 import scala.util.control.Breaks._
-import scala.collection.mutable
+//import scala.collection.mutable
 import org.ekrich.config._
 
 object ConfigDocumentParser {
@@ -53,7 +53,7 @@ object ConfigDocumentParser {
       val tokens: ju.Iterator[Token]
   ) {
     private var lineNumber = 1
-    final private var buffer = new mutable.Stack[Token]
+    final private val buffer = new ju.ArrayDeque[Token]
     // this is the number of "equals" we are inside,
     // used to modify the error message to reflect that
     // someone may think this is .properties format.

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImpl.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImpl.scala
@@ -10,7 +10,6 @@ import java.net.URL
 import java.time.Duration
 import java.{util => ju}
 import java.util.concurrent.Callable
-import scala.jdk.CollectionConverters._
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigIncluder
@@ -258,7 +257,7 @@ object ConfigImpl {
         return emptyObject(origin)
       if (mapMode == FromMapMode.KEYS_ARE_KEYS) {
         val values = new ju.HashMap[String, AbstractConfigValue]
-        for (entry <- obj.asInstanceOf[ju.Map[_, _]].entrySet.asScala) {
+        obj.asInstanceOf[ju.Map[_, _]].entrySet.forEach { entry =>
           val key = entry.getKey
           if (!key.isInstanceOf[String])
             throw new ConfigException.BugOrBroken(
@@ -306,7 +305,7 @@ object ConfigImpl {
     val systemProperties = System.getProperties
     val systemPropertiesCopy = new ju.Properties
     systemProperties.synchronized {
-      for (entry <- systemProperties.entrySet().asScala) {
+      systemProperties.entrySet().forEach { entry =>
         // Java 11 introduces 'java.version.date', but we don't want that to
         // overwrite 'java.version'
         if (!entry.getKey().toString().startsWith("java.version.")) {
@@ -408,7 +407,7 @@ object ConfigImpl {
       if (s == null) result
       else {
         val keys = s.split(",")
-        for (k <- keys) {
+        keys.foreach { k =>
           if (k == LOADS)
             result.put(LOADS, true)
           else if (k == SUBSTITUTIONS)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
@@ -199,7 +199,7 @@ object ConfigImplUtil {
   private[impl] def toCamelCase(originalName: String): String = {
     val words = originalName.split("-+")
     val nameBuilder = new StringBuilder(originalName.length)
-    for (word <- words) {
+    words.foreach { word =>
       if (nameBuilder.length == 0) nameBuilder.append(word)
       else {
         nameBuilder.append(word.substring(0, 1).toUpperCase)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
@@ -10,12 +10,12 @@ import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.net.URISyntaxException
 import java.net.URL
-import java.{util => ju}
-import scala.jdk.CollectionConverters._
-import scala.util.control.Breaks._
+import java.util as ju
+import scala.util.control.Breaks.*
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigSyntax
+import scala.annotation.varargs
 
 /**
  * Internal implementation detail, not ABI stable, do not touch. For use only by
@@ -172,9 +172,10 @@ object ConfigImplUtil {
     }
   }
   // add Scala vararg version - this is the one finally called now
-  def joinPath(elements: String*): String = new Path(elements: _*).render
+  @varargs def joinPath(elements: String*): String =
+    new Path(elements: _*).render
   def joinPath(elements: ju.List[String]): String =
-    joinPath(elements.asScala.toSeq: _*)
+    joinPath(elements.toArray(new Array[String](0)).toIndexedSeq: _*)
   def splitPath(path: String): ju.List[String] = {
     var p = Path.newPath(path)
     val elements = new ju.ArrayList[String]

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigImplUtil.scala
@@ -11,11 +11,11 @@ import java.io.ObjectOutputStream
 import java.net.URISyntaxException
 import java.net.URL
 import java.util as ju
+import scala.annotation.varargs
 import scala.util.control.Breaks.*
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigSyntax
-import scala.annotation.varargs
 
 /**
  * Internal implementation detail, not ABI stable, do not touch. For use only by

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeComplexValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeComplexValue.scala
@@ -14,8 +14,7 @@ abstract class ConfigNodeComplexValue(
 
   override def tokens: ju.Collection[Token] = {
     val tokens = new ju.ArrayList[Token]
-    import scala.jdk.CollectionConverters._
-    for (child <- children.asScala) {
+    children.forEach { child =>
       tokens.addAll(child.tokens)
     }
     tokens

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
@@ -3,10 +3,9 @@
  */
 package org.ekrich.config.impl
 
-import org.ekrich.config.ConfigException
 import java.{util => ju}
-
-import scala.jdk.CollectionConverters._
+import org.ekrich.config.ConfigException
+import ScalaOps._
 
 final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
     extends AbstractConfigNode {
@@ -55,13 +54,14 @@ final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
   }
 
   private[impl] def separator: Token =
-    children.asScala.iterator
-      .filter(_.isInstanceOf[ConfigNodeSingleToken])
-      .map(_.asInstanceOf[ConfigNodeSingleToken].token)
-      .find { t =>
-        (t eq Tokens.PLUS_EQUALS) || (t eq Tokens.COLON) || (t eq Tokens.EQUALS)
+    children.scalaOps.findFold(child =>
+      child.isInstanceOf[ConfigNodeSingleToken] && {
+        val t = child.asInstanceOf[ConfigNodeSingleToken].token
+        (t == Tokens.PLUS_EQUALS || t == Tokens.COLON || t == Tokens.EQUALS)
       }
-      .getOrElse(null)
+    )(() => null: Token)(child =>
+      child.asInstanceOf[ConfigNodeSingleToken].token
+    )
 
   private[impl] def comments: ju.List[String] = {
     val comments = new ju.ArrayList[String]

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeField.scala
@@ -5,6 +5,7 @@ package org.ekrich.config.impl
 
 import org.ekrich.config.ConfigException
 import java.{util => ju}
+
 import scala.jdk.CollectionConverters._
 
 final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
@@ -13,7 +14,7 @@ final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
 
   override def tokens: ju.Collection[Token] = {
     val tokens = new ju.ArrayList[Token]
-    for (child <- children.asScala) {
+    children.forEach { child =>
       tokens.addAll(child.tokens)
     }
     tokens
@@ -64,7 +65,7 @@ final class ConfigNodeField(_children: ju.Collection[AbstractConfigNode])
 
   private[impl] def comments: ju.List[String] = {
     val comments = new ju.ArrayList[String]
-    for (child <- children.asScala) {
+    children.forEach { child =>
       if (child.isInstanceOf[ConfigNodeComment])
         comments.add(child.asInstanceOf[ConfigNodeComment].commentText)
     }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
@@ -1,7 +1,7 @@
 package org.ekrich.config.impl
 
 import java.{util => ju}
-import scala.jdk.CollectionConverters._
+import ScalaOps._
 
 final class ConfigNodeInclude(
     final val children: ju.Collection[AbstractConfigNode],
@@ -16,14 +16,13 @@ final class ConfigNodeInclude(
     tokens
   }
 
-  private[impl] def name: String = {
-    children.asScala.find(_.isInstanceOf[ConfigNodeSimpleValue]) match {
-      case Some(node) =>
-        Tokens
-          .getValue(node.asInstanceOf[ConfigNodeSimpleValue].token)
-          .unwrapped
-          .asInstanceOf[String]
-      case None => null
-    }
-  }
+  private[impl] def name: String =
+    children.scalaOps.findFold(_.isInstanceOf[ConfigNodeSimpleValue])(() =>
+      null: String
+    )(node =>
+      Tokens
+        .getValue(node.asInstanceOf[ConfigNodeSimpleValue].token)
+        .unwrapped
+        .asInstanceOf[String]
+    )
 }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeInclude.scala
@@ -10,7 +10,7 @@ final class ConfigNodeInclude(
 ) extends AbstractConfigNode {
   override def tokens: ju.Collection[Token] = {
     val tokens = new ju.ArrayList[Token]
-    for (child <- children.asScala) {
+    children.forEach { child =>
       tokens.addAll(child.tokens)
     }
     tokens

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeObject.scala
@@ -1,9 +1,9 @@
 package org.ekrich.config.impl
 
 import org.ekrich.config.ConfigSyntax
-import java.{util => ju}
-import scala.jdk.CollectionConverters._
+import java.util as ju
 import scala.util.control.Breaks._
+import ScalaOps.*
 
 final class ConfigNodeObject private[impl] (
     _children: ju.Collection[AbstractConfigNode]
@@ -14,11 +14,11 @@ final class ConfigNodeObject private[impl] (
     new ConfigNodeObject(nodes)
 
   def hasValue(desiredPath: Path): Boolean =
-    children.asScala.exists {
+    children.scalaOps.exists {
       case field: ConfigNodeField => {
         val path = field.path.value
         if (path == desiredPath || path.startsWith(desiredPath)) true
-        else if (desiredPath.startsWith(path)) {
+        else if (desiredPath.startsWith(path))
           field.value match {
             case obj: ConfigNodeObject =>
               val remainingPath = desiredPath.subPath(path.length)
@@ -26,7 +26,7 @@ final class ConfigNodeObject private[impl] (
               else false
             case _ => false
           }
-        } else false
+        else false
       }
       case _ => false
     }
@@ -229,7 +229,11 @@ final class ConfigNodeObject private[impl] (
     // If the path is of length greater than one, see if the value needs to be added further down
     if (path.length > 1) {
       val lastIndex = children.size - 1
-      val index = children.asScala.reverse.indexWhere { v =>
+      // children array is mutable
+      val childrenReverseCopy = new ju.ArrayList[AbstractConfigNode](children)
+      // reverse so we find the last index that matches
+      ju.Collections.reverse(childrenReverseCopy)
+      val index = childrenReverseCopy.scalaOps.indexWhere { v =>
         v match {
           case node: ConfigNodeField =>
             val key: Path = node.path.value

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeRoot.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigNodeRoot.scala
@@ -1,10 +1,10 @@
 package org.ekrich.config.impl
 
-import java.{util => ju}
-import scala.jdk.CollectionConverters._
+import java.util as ju
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigSyntax
+import ScalaOps._
 
 final class ConfigNodeRoot private[impl] (
     _children: ju.Collection[AbstractConfigNode],
@@ -15,16 +15,18 @@ final class ConfigNodeRoot private[impl] (
   ): ConfigNodeComplexValue =
     throw new ConfigException.BugOrBroken("Tried to indent the root object")
 
-  private[impl] def value: ConfigNodeComplexValue =
-    children.asScala.find(node =>
-      node.isInstanceOf[ConfigNodeComplexValue]
-    ) match {
-      case Some(node) => node.asInstanceOf[ConfigNodeComplexValue]
-      case None       =>
-        throw new ConfigException.BugOrBroken(
-          "ConfigNodeRoot did not contain a value"
-        )
-    }
+  private[impl] def value: ConfigNodeComplexValue = {
+    val complexNode =
+      children.scalaOps.findFold(_.isInstanceOf[ConfigNodeComplexValue])(() =>
+        null: ConfigNodeComplexValue
+      )(node => node.asInstanceOf[ConfigNodeComplexValue])
+
+    if (complexNode != null) complexNode
+    else
+      throw new ConfigException.BugOrBroken(
+        "ConfigNodeRoot did not contain a value"
+      )
+  }
 
   private[impl] def setValue(
       desiredPath: String,

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigParser.scala
@@ -7,10 +7,7 @@ import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
-
-import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
-
 import org.ekrich.config._
 
 object ConfigParser {
@@ -96,7 +93,7 @@ object ConfigParser {
           "Found a concatenation node in JSON"
         )
       val values = new ju.ArrayList[AbstractConfigValue](n.children.size)
-      for (node <- n.children.asScala) {
+      n.children.forEach { node =>
         var v: AbstractConfigValue = null
         if (node.isInstanceOf[AbstractConfigNodeValue]) {
           v = parseValue(node.asInstanceOf[AbstractConfigNodeValue], null)
@@ -200,7 +197,7 @@ object ConfigParser {
         val prefix = fullCurrentPath
         obj = obj.relativized(prefix)
       }
-      for (key <- obj.keySet.asScala) {
+      obj.keySet.forEach { key =>
         val v = obj.get(key)
         val existing = values.get(key)
         if (existing != null) values.put(key, v.withFallback(existing))
@@ -353,7 +350,7 @@ object ConfigParser {
       var lastWasNewLine = false
       val comments = new ju.ArrayList[String]
       var v: AbstractConfigValue = null
-      for (node <- n.children.asScala) {
+      n.children.forEach { node =>
         if (node.isInstanceOf[ConfigNodeComment]) {
           comments.add(node.asInstanceOf[ConfigNodeComment].commentText)
           lastWasNewLine = false
@@ -399,7 +396,7 @@ object ConfigParser {
       val comments = new ju.ArrayList[String]
       var lastWasNewLine = false
       breakable {
-        for (node <- document.children.asScala) {
+        document.children.forEach { node =>
           if (node.isInstanceOf[ConfigNodeComment]) {
             comments.add(node.asInstanceOf[ConfigNodeComment].commentText)
             lastWasNewLine = false

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/DefaultTransformer.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/DefaultTransformer.scala
@@ -7,7 +7,6 @@ import java.{lang => jl}
 import java.{util => ju}
 import java.util.Collections
 import java.util.Comparator
-import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 import org.ekrich.config.ConfigValueType
 import org.ekrich.config.ConfigValueType._
@@ -78,7 +77,7 @@ object DefaultTransformer {
       // empty objects here though :-/
       val o = value.asInstanceOf[AbstractConfigObject]
       val values = new ju.HashMap[Integer, AbstractConfigValue]
-      for (key <- o.keySet.asScala) {
+      o.keySet.forEach { key =>
         breakable {
           var i = 0
           try {
@@ -113,7 +112,7 @@ object DefaultTransformer {
         // drop the indices (we allow gaps in the indices, for better or
         // worse)
         val list = new ju.ArrayList[AbstractConfigValue]
-        for (entry <- entryList.asScala) {
+        entryList.forEach { entry =>
           list.add(entry.getValue)
         }
         retVal = new SimpleConfigList(value.origin, list)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Path.scala
@@ -16,11 +16,6 @@ object Path {
 
   def newPath(path: String): Path = PathParser.parsePath(path)
 
-  private def convert(i: ju.Iterator[Path]): Seq[String] = {
-    import scala.jdk.CollectionConverters._
-    i.asScala.toSeq.map(_.first)
-  }
-
   /**
    * @return
    *   path minus the first element or null if no more elements

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
@@ -4,9 +4,7 @@
 package org.ekrich.config.impl
 
 import java.util as ju
-
 import scala.util.control.Breaks._
-
 import org.ekrich.config.ConfigException
 
 final class PathBuilder private[impl] () {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathBuilder.scala
@@ -3,13 +3,14 @@
  */
 package org.ekrich.config.impl
 
-import util.control.Breaks._
+import java.util as ju
+
+import scala.util.control.Breaks._
+
 import org.ekrich.config.ConfigException
 
-import scala.collection.mutable
-
 final class PathBuilder private[impl] () {
-  final private val keys = new mutable.Stack[String]
+  final private val keys = new ju.ArrayDeque[String]
   // the keys are kept "backward" (top of stack is end of path)
   private var resultPath: Path = null
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PathParser.scala
@@ -159,8 +159,7 @@ object PathParser {
       }
     }
     val pb = new PathBuilder
-    import scala.jdk.CollectionConverters._
-    for (e <- buf.asScala) {
+    buf.forEach { e =>
       if (e.sb.length == 0 && !e.canBeEmpty)
         throw new ConfigException.BadPath(
           origin,
@@ -180,7 +179,7 @@ object PathParser {
     if (tokenText == ".") return ju.Collections.singletonList(t)
     val splitToken = tokenText.split("\\.")
     val splitTokens = new ju.ArrayList[Token]
-    for (s <- splitToken) {
+    splitToken.foreach { s =>
       if (flavor eq ConfigSyntax.CONF)
         splitTokens.add(Tokens.newUnquotedText(t.origin, s))
       else splitTokens.add(Tokens.newString(t.origin, s, "\"" + s + "\""))

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/PropertiesParser.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/PropertiesParser.scala
@@ -9,7 +9,6 @@ import java.{util => ju}
 import java.util.Collections
 import java.util.Comparator
 import java.util.Properties
-import scala.jdk.CollectionConverters._
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 
@@ -67,7 +66,7 @@ object PropertiesParser {
       map: ju.Map[_ <: AnyRef, _ <: AnyRef]
   ): ju.Map[Path, AnyRef] = {
     val pathMap = new ju.HashMap[Path, AnyRef]
-    for (entry <- map.entrySet().asScala) {
+    map.entrySet.forEach { entry =>
       val key = entry.getKey
       if (key.isInstanceOf[String]) {
         val path = pathFromPropertyKey(key.asInstanceOf[String])
@@ -82,7 +81,7 @@ object PropertiesParser {
       pathExpressionMap: ju.Map[_, _]
   ): AbstractConfigObject = {
     val pathMap = new ju.HashMap[Path, AnyRef]
-    for (entry <- pathExpressionMap.entrySet.asScala) {
+    pathExpressionMap.entrySet.forEach { entry =>
       val keyObj = entry.getKey
       if (!keyObj.isInstanceOf[String])
         throw new ConfigException.BugOrBroken(
@@ -105,7 +104,7 @@ object PropertiesParser {
      */
     val scopePaths = new ju.HashSet[Path]
     val valuePaths = new ju.HashSet[Path]
-    for (path <- pathMap.keySet.asScala) { // add value's path
+    pathMap.keySet.forEach { path => // add value's path
       valuePaths.add(path)
       // all parent paths are objects
       var next = path.parent
@@ -122,7 +121,7 @@ object PropertiesParser {
       valuePaths.removeAll(scopePaths)
     } else {
       /* If we didn't start out as properties, then this is an error. */
-      for (path <- valuePaths.asScala) {
+      valuePaths.forEach { path =>
         if (scopePaths.contains(path))
           throw new ConfigException.BugOrBroken(
             "In the map, path '" + path.render + "' occurs as both the parent object of a value and as a value. " +
@@ -135,12 +134,12 @@ object PropertiesParser {
      */
     val root = new ju.HashMap[String, AbstractConfigValue]
     val scopes = new ju.HashMap[Path, ju.Map[String, AbstractConfigValue]]
-    for (path <- scopePaths.asScala) {
+    scopePaths.forEach { path =>
       val scope = new ju.HashMap[String, AbstractConfigValue]
       scopes.put(path, scope)
     }
     /* Store string values in the associated scope maps */
-    for (path <- valuePaths.asScala) {
+    valuePaths.forEach { path =>
       val parentPath = path.parent
       val parent =
         if (parentPath != null) scopes.get(parentPath) else root
@@ -188,7 +187,7 @@ object PropertiesParser {
      * parents to avoid modifying any already-created ConfigObject. This is
      * where we need the sorted list.
      */
-    for (scopePath <- sortedScopePaths.asScala) {
+    sortedScopePaths.forEach { scopePath =>
       val scope = scopes.get(scopePath)
       val parentPath = scopePath.parent
       val parent =

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveContext.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ResolveContext.scala
@@ -113,8 +113,7 @@ private[impl] final class ResolveContext(
   private[impl] def traceString: String = {
     val separator = ", "
     val sb = new StringBuilder
-    import scala.jdk.CollectionConverters._
-    for (value <- resolveStack.asScala) {
+    resolveStack.forEach { value =>
       if (value.isInstanceOf[ConfigReference]) {
         sb.append(value.asInstanceOf[ConfigReference].expression.toString)
         sb.append(separator)

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
@@ -15,11 +15,9 @@ import java.io.NotSerializableException
 import java.io.ObjectInput
 import java.io.ObjectOutput
 import java.io.ObjectStreamException
-import java.{lang => jl}
-import java.{util => ju}
-
-import scala.util.control.Breaks._
-
+import java.lang as jl
+import java.util as ju
+import scala.util.control.Breaks.*
 import org.ekrich.config.Config
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigList

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SerializedConfigValue.scala
@@ -18,7 +18,6 @@ import java.io.ObjectStreamException
 import java.{lang => jl}
 import java.{util => ju}
 
-import scala.jdk.CollectionConverters._
 import scala.util.control.Breaks._
 
 import org.ekrich.config.Config
@@ -64,7 +63,7 @@ object SerializedConfigValue {
       case ORIGIN_COMMENTS        =>
         val list = v.asInstanceOf[ju.List[String]]
         out.writeInt(list.size)
-        for (s <- list.asScala) {
+        list.forEach { s =>
           out.writeUTF(s)
         }
       case ORIGIN_NULL_URL      => () // FALL THRU
@@ -88,7 +87,7 @@ object SerializedConfigValue {
       m = origin.toFieldsDelta(baseOrigin)
     else
       m = ju.Collections.emptyMap[SerializedField, AnyRef]
-    for (e <- m.entrySet.asScala) {
+    m.entrySet.forEach { e =>
       val field = new FieldOut(e.getKey)
       val v = e.getValue
       writeOriginField(field.data, field.code, v)
@@ -180,13 +179,13 @@ object SerializedConfigValue {
       case LIST =>
         val list = value.asInstanceOf[ConfigList]
         out.writeInt(list.size)
-        for (v <- list.asScala) {
+        list.forEach { v =>
           writeValue(out, v, list.origin.asInstanceOf[SimpleConfigOrigin])
         }
       case OBJECT =>
         val obj = value.asInstanceOf[ConfigObject]
         out.writeInt(obj.size)
-        for (e <- obj.entrySet.asScala) {
+        obj.entrySet.forEach { e =>
           out.writeUTF(e.getKey)
           writeValue(
             out,

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfig.scala
@@ -918,9 +918,10 @@ final class SimpleConfig private[impl] (val confObj: AbstractConfigObject)
       case e: IllegalArgumentException =>
         val enumNames = new ju.ArrayList[String]
         val enumConstants = enumClass.getEnumConstants
-        if (enumConstants != null) for (enumConstant <- enumConstants) {
-          enumNames.add(enumConstant.name)
-        }
+        if (enumConstants != null)
+          enumConstants.foreach { enumConstant =>
+            enumNames.add(enumConstant.name)
+          }
         throw new ConfigException.BadValue(
           enumConfigValue.origin,
           path,
@@ -1103,7 +1104,7 @@ final class SimpleConfig private[impl] (val confObj: AbstractConfigObject)
     if (restrictToPaths.length == 0)
       SimpleConfig.checkValidObject(null, ref.root, root, problems)
     else
-      for (p <- restrictToPaths) {
+      restrictToPaths.foreach { p =>
         val path = Path.newPath(p)
         val refValue = ref.peekPath(path)
         if (refValue != null) {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
@@ -8,7 +8,6 @@ import java.io.Serializable
 import java.{lang => jl}
 import java.{util => ju}
 
-import scala.jdk.CollectionConverters._
 import org.ekrich.config._
 import org.ekrich.config.impl.AbstractConfigValue._
 
@@ -75,7 +74,7 @@ final class SimpleConfigList(
 
   override def unwrapped: ju.List[AnyRef] = {
     val list = new ju.ArrayList[AnyRef]
-    for (v <- value.asScala) {
+    value.forEach { v =>
       list.add(v.unwrapped.asInstanceOf[AnyRef])
     }
     list
@@ -115,7 +114,7 @@ final class SimpleConfigList(
     // lazy-create for optimization
     var changed: ju.List[AbstractConfigValue] = null
     var i = 0
-    for (v <- value.asScala) {
+    value.forEach { v =>
       val modified = modifier.modifyChildMayThrow(null /* key */, v)
       // lazy-create the new list if required
       if (changed == null && (modified ne v)) {
@@ -202,10 +201,10 @@ final class SimpleConfigList(
     else {
       sb.append("[")
       if (options.getFormatted) sb.append('\n')
-      for (v <- value.asScala) {
+      value.forEach { v =>
         if (options.getOriginComments) {
           val lines = v.origin.description.split("\n")
-          for (l <- lines) {
+          lines.foreach { l =>
             indent(sb, indentVal + 1, options)
             sb.append('#')
             if (!l.isEmpty) sb.append(' ')
@@ -214,7 +213,7 @@ final class SimpleConfigList(
           }
         }
         if (options.getComments) {
-          for (comment <- v.origin.comments.asScala) {
+          v.origin.comments.forEach { comment =>
             indent(sb, indentVal + 1, options)
             sb.append("#")
             if (!comment.startsWith(" ")) sb.append(' ')
@@ -275,7 +274,7 @@ final class SimpleConfigList(
   override def subList(fromIndex: Int, toIndex: Int): ju.List[ConfigValue] = {
     val list = new ju.ArrayList[ConfigValue]
     // yay bloat caused by lack of type variance
-    for (v <- value.subList(fromIndex, toIndex).asScala) {
+    value.subList(fromIndex, toIndex).forEach { v =>
       list.add(v)
     }
     list

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
@@ -5,11 +5,10 @@ package org.ekrich.config.impl
 
 import java.io.ObjectStreamException
 import java.io.Serializable
-import java.{lang => jl}
-import java.{util => ju}
-
-import org.ekrich.config._
-import org.ekrich.config.impl.AbstractConfigValue._
+import java.lang as jl
+import java.util as ju
+import org.ekrich.config.*
+import org.ekrich.config.impl.AbstractConfigValue.*
 
 @SerialVersionUID(2L)
 object SimpleConfigList {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -8,16 +8,14 @@ import java.io.Serializable
 import java.util as ju
 import java.lang as jl
 import java.math.BigInteger
-
 import scala.util.control.Breaks.*
-
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigObject
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions
 import org.ekrich.config.ConfigValue
 import org.ekrich.config.impl.AbstractConfigValue.NotPossibleToResolve
-import org.ekrich.config.impl.ScalaOps.*
+import ScalaOps.*
 
 @SerialVersionUID(2L)
 object SimpleConfigObject {

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -8,14 +8,17 @@ import java.io.Serializable
 import java.util as ju
 import java.lang as jl
 import java.math.BigInteger
+
 import scala.jdk.CollectionConverters.*
 import scala.util.control.Breaks.*
+
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigObject
 import org.ekrich.config.ConfigOrigin
 import org.ekrich.config.ConfigRenderOptions
 import org.ekrich.config.ConfigValue
 import org.ekrich.config.impl.AbstractConfigValue.NotPossibleToResolve
+import org.ekrich.config.impl.ScalaOps.*
 
 @SerialVersionUID(2L)
 object SimpleConfigObject {
@@ -126,7 +129,7 @@ object SimpleConfigObject {
   ) =
     if (a eq b) true
     else if (a.keySet != b.keySet) false
-    else !a.keySet.asScala.exists(key => a.get(key) != b.get(key))
+    else !a.keySet.scalaOps.exists(key => a.get(key) != b.get(key))
 
   private def mapHash(m: ju.Map[String, ConfigValue]): Int = {
     // the keys have to be sorted, otherwise we could be equal
@@ -252,7 +255,7 @@ final class SimpleConfigObject(
       this
     } else {
       val smaller = new ju.HashMap[String, AbstractConfigValue](value.size - 1)
-      for (old <- value.entrySet.asScala) {
+      value.entrySet.forEach { old =>
         if (!(old.getKey == key)) smaller.put(old.getKey, old.getValue)
       }
       new SimpleConfigObject(
@@ -356,9 +359,9 @@ final class SimpleConfigObject(
 
   // related to AbstractConfigValue.hasDescendantInList
   override def hasDescendant(descendant: AbstractConfigValue): Boolean =
-    value.values.asScala.exists(_ eq descendant) ||
+    value.values.scalaOps.exists(_ eq descendant) ||
       // now the expensive traversal
-      value.values.asScala.exists(
+      value.values.scalaOps.exists(
         _ match {
           case v: Container => v.hasDescendant(descendant)
           case _            => false
@@ -368,7 +371,7 @@ final class SimpleConfigObject(
   override def unwrapped: ju.Map[String, AnyRef] = {
     val m = new ju.HashMap[String, AnyRef]
 
-    for (e <- value.entrySet.asScala) {
+    value.entrySet.forEach { e =>
       m.put(e.getKey, e.getValue.unwrapped)
     }
     m
@@ -390,7 +393,7 @@ final class SimpleConfigObject(
     allKeys.addAll(this.keySet)
     allKeys.addAll(fallback.keySet)
 
-    for (key <- allKeys.asScala) {
+    allKeys.forEach { key =>
       val first = this.value.get(key)
       val second = fallback.value.get(key)
       var kept: AbstractConfigValue = null
@@ -427,7 +430,7 @@ final class SimpleConfigObject(
   @throws[Exception]
   private def modifyMayThrow(modifier: AbstractConfigValue.Modifier) = {
     var changes: ju.Map[String, AbstractConfigValue] = null
-    for (k <- keySet.asScala) {
+    keySet.forEach { k =>
       val v = value.get(k)
       // "modified" may be null, which means remove the child;
       // to do that we put null in the "changes" map.
@@ -442,7 +445,7 @@ final class SimpleConfigObject(
     else {
       val modified = new ju.HashMap[String, AbstractConfigValue]
       var sawUnresolved = false
-      for (k <- keySet.asScala) {
+      keySet.forEach { k =>
         if (changes.containsKey(k)) {
           val newValue = changes.get(k)
           if (newValue != null) {
@@ -588,12 +591,12 @@ final class SimpleConfigObject(
       else new SimpleConfigObject.OrderedRenderComparator
     ju.Collections.sort(keys, ordering)
 
-    for (k <- keys.asScala) {
+    keys.forEach { k =>
       var v: AbstractConfigValue = null
       v = value.get(k)
       if (options.getOriginComments) {
         val lines = v.origin.description.split("\n")
-        for (l <- lines) {
+        lines.foreach { l =>
           AbstractConfigValue.indent(sb, indentVal + 1, options)
           sb.append('#')
           if (!l.isEmpty) sb.append(' ')
@@ -602,7 +605,7 @@ final class SimpleConfigObject(
         }
       }
       if (options.getComments) {
-        for (comment <- v.origin.comments.asScala) {
+        v.origin.comments.forEach { comment =>
           AbstractConfigValue.indent(sb, innerIndent, options)
           sb.append("#")
           if (!comment.startsWith(" ")) sb.append(' ')
@@ -667,7 +670,7 @@ final class SimpleConfigObject(
   override def entrySet: ju.Set[ju.Map.Entry[String, ConfigValue]] = {
     // total bloat just to work around lack of type variance
     val entries = new ju.HashSet[ju.Map.Entry[String, ConfigValue]]
-    for (e <- value.entrySet.asScala) {
+    value.entrySet.forEach { e =>
       entries.add(
         new ju.AbstractMap.SimpleImmutableEntry[String, ConfigValue](
           e.getKey,

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigObject.scala
@@ -128,14 +128,14 @@ object SimpleConfigObject {
     else if (a.keySet != b.keySet) false
     else !a.keySet.asScala.exists(key => a.get(key) != b.get(key))
 
-  private def mapHash(m: ju.Map[String, ConfigValue]) = {
+  private def mapHash(m: ju.Map[String, ConfigValue]): Int = {
     // the keys have to be sorted, otherwise we could be equal
     // to another map but have a different hashcode.
     val keys = new ju.ArrayList[String]
     keys.addAll(m.keySet)
     ju.Collections.sort(keys)
     var valuesHash = 0
-    for (k <- keys.asScala) {
+    keys.forEach { k =>
       valuesHash += m.get(k).hashCode
     }
     41 * (41 + keys.hashCode) + valuesHash

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
@@ -9,7 +9,7 @@ import java.{lang => jl}
 import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
-import scala.jdk.CollectionConverters._
+
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 
@@ -191,7 +191,7 @@ object SimpleConfigOrigin {
       stack: ju.List[_ <: AbstractConfigValue]
   ): ConfigOrigin = {
     val origins = new ju.ArrayList[ConfigOrigin](stack.size)
-    for (v <- stack.asScala) {
+    stack.forEach { v =>
       origins.add(v.origin)
     }
     mergeOrigins(origins)
@@ -212,7 +212,7 @@ object SimpleConfigOrigin {
     } else {
       val remaining =
         new ju.ArrayList[SimpleConfigOrigin](stack.size)
-      for (o <- stack.asScala) {
+      stack.forEach { o =>
         remaining.add(o.asInstanceOf[SimpleConfigOrigin])
       }
       while (remaining.size > 2) {
@@ -238,7 +238,7 @@ object SimpleConfigOrigin {
       child: ju.Map[SerializedField, AnyRef]
   ): ju.Map[SerializedField, AnyRef] = {
     val m = new ju.TreeMap[SerializedField, AnyRef](child) // was EnumMap
-    for (baseEntry <- base.entrySet.asScala) {
+    base.entrySet.forEach { baseEntry =>
       val f = baseEntry.getKey
       if (m.containsKey(f) && ConfigImplUtil.equalsHandlingNull(
             baseEntry.getValue,
@@ -331,7 +331,7 @@ object SimpleConfigOrigin {
       delta: ju.Map[SerializedField, AnyRef]
   ): ju.Map[SerializedField, AnyRef] = {
     val m = new ju.TreeMap[SerializedField, AnyRef](delta) // was EnumMap
-    for (baseEntry <- base.entrySet.asScala) {
+    base.entrySet.forEach { baseEntry =>
       val f = baseEntry.getKey
       if (delta.containsKey(f)) {
         // delta overrides when keys are in both

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigOrigin.scala
@@ -5,11 +5,10 @@ package org.ekrich.config.impl
 
 import java.io.File
 import java.io.IOException
-import java.{lang => jl}
+import java.lang as jl
 import java.net.MalformedURLException
 import java.net.URL
-import java.{util => ju}
-
+import java.util as ju
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigOrigin
 

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
@@ -6,8 +6,7 @@ package org.ekrich.config.impl
 import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
-import java.{util => ju}
-
+import java.util as ju
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigFactory
 import org.ekrich.config.ConfigIncludeContext

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleIncluder.scala
@@ -7,7 +7,6 @@ import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import java.{util => ju}
-import scala.jdk.CollectionConverters._
 
 import org.ekrich.config.ConfigException
 import org.ekrich.config.ConfigFactory
@@ -176,7 +175,7 @@ object SimpleIncluder {
           )
         } else {
           val sb = new StringBuilder
-          for (t <- fails.asScala) {
+          fails.forEach { t =>
             sb.append(t.getMessage)
             sb.append(", ")
           }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokenizer.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokenizer.scala
@@ -346,7 +346,7 @@ object Tokenizer {
       catch {
         case e: NumberFormatException =>
           // not a number after all, see if it's an unquoted string.
-          for (u <- s.toCharArray) {
+          s.toCharArray.foreach { u =>
             if (TokenIterator.notInUnquotedText.indexOf(u.toInt) >= 0)
               throw problem(
                 asString(u.toInt),

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokens.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/Tokens.scala
@@ -162,8 +162,7 @@ object Tokens {
       ) + "}"
     override def toString(): String = {
       val sb = new StringBuilder
-      import scala.jdk.CollectionConverters._
-      for (t <- value.asScala) {
+      value.forEach { t =>
         sb.append(t.toString)
       }
       "'${" + sb.toString + "}'"

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigFormatOptionsTest.scala
@@ -248,9 +248,6 @@ class ConfigFormatOptionsTest extends TestUtilsShared {
         |}
         |""".stripMargin
 
-    println(result)
-    println(expected)
-
     checkEqualObjects(expected, result)
   }
 


### PR DESCRIPTION
The library is still used for test. Testing was the original part of the project that was Scala so it is needed to handle Scala version collection differences.

This change uses Java `forEach` and ScalaOps (from Scala.js and Scala Native javalib) to have some functional like methods. ScalaOps uses Java `Function`, `Supplier`, `Consumer` and `BiFunction` to make the functions Scala free.

Removing the dependency and not converting Java collections to Scala and visa versa is a big win. This includes a tail recursive function using a Java collection.