### PR TITLE
Fix doc generation for sbt 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,9 +63,16 @@ Compile / console / scalacOptions --= Seq(
   "-Xfatal-warnings"
 )
 
-Compile / doc / scalacOptions ++= Seq(
-  "-external-mappings:java\\..*::javadoc::https://docs.oracle.com/en/java/javase/17/docs/api/"
-)
+Compile / doc / scalacOptions ++= {
+  if (isScala3.value) {
+    Seq(
+      "-groups",
+      "-external-mappings:java\\..*::javadoc::https://docs.oracle.com/en/java/javase/17/docs/api/"
+    )
+  } else {
+    Seq.empty
+  }
+}
 
 val isScala3 = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.7
+sbt.version=2.0.8


### PR DESCRIPTION
Apparently, we do not test doc generation in CI so this was not discovered until snapshot publishing. We need to do the following:

1. Add doc generation to CI
2. Fix the sbt build so docs get published

Note: this project uses sbt-crossproject so it is unclear at this time what the advantages or disadvantages of using this or the built in cross project.