### PR TITLE
Port lightbend/config#832 and #841: two rendering round-trip fixes (#2)

### DIFF
--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigString.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigString.scala
@@ -69,9 +69,9 @@ object ConfigString {
       } else {
         val rendered =
           if (options.getJson) ConfigImplUtil.renderJsonString(value)
-          else if (value == " ") // might need more cases to disable quotes wrapping
-            value
-          else ConfigImplUtil.renderStringUnquotedIfPossible(value)
+          // this value was never quoted in the source (it's a ConfigString.Unquoted),
+          // so re-emit it verbatim instead of re-quoting it - matches lightbend/config#841
+          else value
         sb.append(rendered)
       }
   }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
@@ -226,14 +226,14 @@ final class SimpleConfigList(
         if (options.getConfigFormatOptions.getSimplifyNestedObjects && v
               .isInstanceOf[SimpleConfigObject]) {
           val redact = new jl.StringBuilder()
-          v.renderValue(redact, indentVal + 1, atRoot, options)
+          v.renderValue(redact, indentVal + 1, false, options)
           if (redact.charAt(redact.length() - 1) != '}') {
             redact.insert(0, "{ ")
             redact.append(" }")
           } // else no bonus chars added
           sb.append(redact.toString)
         } else
-          v.renderValue(sb, indentVal + 1, atRoot, options)
+          v.renderValue(sb, indentVal + 1, false, options)
 
         sb.append(",")
         if (options.getFormatted) sb.append('\n')

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigDefaultRenderingTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigDefaultRenderingTest.scala
@@ -1,7 +1,12 @@
 package org.ekrich.config.impl
 
 import org.junit.*
+import org.junit.Assert.*
+import org.ekrich.config.ConfigFactory
 import org.ekrich.config.ConfigFormatOptions
+import org.ekrich.config.ConfigParseOptions
+
+import scala.jdk.CollectionConverters.*
 
 // Regression tests for rendering old behaviour compatibility
 class ConfigDefaultRenderingTest extends RenderingTestSuite {
@@ -86,5 +91,38 @@ class ConfigDefaultRenderingTest extends RenderingTestSuite {
         |myEmpty = " "
         |""".stripMargin
     checkEqualsAndStable(expected, result)
+  }
+
+  // an object nested inside an array is never itself "at root" - it always
+  // needs its own braces, first entry included. Porting lightbend/config#832.
+  @Test
+  def listElementsKeepTheirBraces(): Unit = {
+    val in = """root = [{foo = bar}, {baz = qux}]"""
+    val result = formatHocon(in)
+
+    val expected = """root = [
+                     |    {
+                     |        foo = bar
+                     |    },
+                     |    {
+                     |        baz = qux
+                     |    }
+                     |]
+                     |""".stripMargin
+    checkEqualsAndStable(expected, result)
+  }
+
+  // the space between two substitutions in a concatenation is unquoted in
+  // the source; re-quoting it on render turns a valid array concatenation
+  // into a parse error on the way back in. Porting lightbend/config#841.
+  @Test
+  def arrayConcatenationRoundTripsThroughRender(): Unit = {
+    val in = """ex1 = [1, 2]
+               |except = ${ex1} ${ex1}""".stripMargin
+    val result = formatHocon(in)
+
+    val resolved =
+      ConfigFactory.parseString(result, ConfigParseOptions.defaults).resolve()
+    assertEquals(List(1, 2, 1, 2), resolved.getIntList("except").asScala)
   }
 }


### PR DESCRIPTION
Ports two small, independent rendering fixes from lightbend/config that were merged there after this fork's last sync point and are still present here:

https://github.com/lightbend/config/pull/832 
— Render list elements as non-root always. SimpleConfigList.renderValue forwarded the list's own atRoot flag to each element instead of false. An object as the first entry of a root-level array lost its { } in non-JSON output: root = [{foo = bar}] rendered as root = [foo = bar], which does not parse back.
    
https://github.com/lightbend/config/pull/841 
— fix: rendering of substituted list with space. ConfigString.Unquoted only special-cased a literal single-space value (from an earlier, narrower fix in https://github.com/ekrich/sconfig/pull/516) to avoid re-quoting it. Any other unquoted separator still went through renderStringUnquotedIfPossible, which re-quotes on whitespace — and quoted whitespace inside a concatenation is a parse error per the HOCON spec. An unquoted string was never quoted in the source to begin with, so it's now always emitted verbatim, matching upstream's !wasQuoted() check.