### PR TITLE
Port lightbend/config#839+#846: don't evaluate substitutions hidden by values from resolved objects - #3#3

### DIFF
--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigString.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/ConfigString.scala
@@ -69,9 +69,9 @@ object ConfigString {
       } else {
         val rendered =
           if (options.getJson) ConfigImplUtil.renderJsonString(value)
-          else if (value == " ") // might need more cases to disable quotes wrapping
-            value
-          else ConfigImplUtil.renderStringUnquotedIfPossible(value)
+          // this value was never quoted in the source (it's a ConfigString.Unquoted),
+          // so re-emit it verbatim instead of re-quoting it - matches lightbend/config#841
+          else value
         sb.append(rendered)
       }
   }

--- a/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
+++ b/sconfig/shared/src/main/scala/org/ekrich/config/impl/SimpleConfigList.scala
@@ -226,14 +226,14 @@ final class SimpleConfigList(
         if (options.getConfigFormatOptions.getSimplifyNestedObjects && v
               .isInstanceOf[SimpleConfigObject]) {
           val redact = new jl.StringBuilder()
-          v.renderValue(redact, indentVal + 1, atRoot, options)
+          v.renderValue(redact, indentVal + 1, false, options)
           if (redact.charAt(redact.length() - 1) != '}') {
             redact.insert(0, "{ ")
             redact.append(" }")
           } // else no bonus chars added
           sb.append(redact.toString)
         } else
-          v.renderValue(sb, indentVal + 1, atRoot, options)
+          v.renderValue(sb, indentVal + 1, false, options)
 
         sb.append(",")
         if (options.getFormatted) sb.append('\n')

--- a/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigDefaultRenderingTest.scala
+++ b/sconfig/shared/src/test/scala/org/ekrich/config/impl/ConfigDefaultRenderingTest.scala
@@ -1,7 +1,12 @@
 package org.ekrich.config.impl
 
 import org.junit.*
+import org.junit.Assert.*
+import org.ekrich.config.ConfigFactory
 import org.ekrich.config.ConfigFormatOptions
+import org.ekrich.config.ConfigParseOptions
+
+import scala.jdk.CollectionConverters.*
 
 // Regression tests for rendering old behaviour compatibility
 class ConfigDefaultRenderingTest extends RenderingTestSuite {
@@ -86,5 +91,38 @@ class ConfigDefaultRenderingTest extends RenderingTestSuite {
         |myEmpty = " "
         |""".stripMargin
     checkEqualsAndStable(expected, result)
+  }
+
+  // an object nested inside an array is never itself "at root" - it always
+  // needs its own braces, first entry included. Porting lightbend/config#832.
+  @Test
+  def listElementsKeepTheirBraces(): Unit = {
+    val in = """root = [{foo = bar}, {baz = qux}]"""
+    val result = formatHocon(in)
+
+    val expected = """root = [
+                     |    {
+                     |        foo = bar
+                     |    },
+                     |    {
+                     |        baz = qux
+                     |    }
+                     |]
+                     |""".stripMargin
+    checkEqualsAndStable(expected, result)
+  }
+
+  // the space between two substitutions in a concatenation is unquoted in
+  // the source; re-quoting it on render turns a valid array concatenation
+  // into a parse error on the way back in. Porting lightbend/config#841.
+  @Test
+  def arrayConcatenationRoundTripsThroughRender(): Unit = {
+    val in = """ex1 = [1, 2]
+               |except = ${ex1} ${ex1}""".stripMargin
+    val result = formatHocon(in)
+
+    val resolved =
+      ConfigFactory.parseString(result, ConfigParseOptions.defaults).resolve()
+    assertEquals(List(1, 2, 1, 2), resolved.getIntList("except").asScala)
   }
 }


### PR DESCRIPTION
Ports lightbend/config#839, in the corrected form it took in lightbend/config#846 — one commit, so there is no broken intermediate to bisect into.

Per the HOCON spec a substitution hidden by a value it cannot merge with is never evaluated. That held for a directly written hiding value, but not for one arriving through a substitution:

```hocon
p: { a : ${y} }
p: ${x}
p: { a : { x : 1 } }
x: { a : 42 }
```

`${y}` was resolved and failed, though nothing of it survives the merge (lightbend/config#838).

`ConfigDelayedMerge.resolveSubstitutions` now stops walking the stack once `merged` ignores fallbacks, and skips an entry whose every key `merged` already holds with a value that ignores fallbacks.

**Reviewing:** use `git diff -w` — the real change is +74/-3; the rest is re-indentation. The stack walk had to become a `while` loop, since `forEach` has no `break`/`continue` and #563 removed `scala.util.control.Breaks`. Both new checks sit where upstream's do, so the next sync still diffs against `ConfigDelayedMerge.java` line for line.

**Why only whole entries are skipped:** #839 first resolved a pruned copy holding just the unshadowed keys, and #846 reverted it — the copy has a fresh identity, so an inner delayed merge walking up the parent chain no longer finds itself in the stack. That reproduces here: implementing the pruning variant makes `partiallyShadowedObjectWithInnerDelayedMergeResolves` fail with `BugOrBroken: tried to replace SimpleConfigObject({"c":...}) which is not in [...]`.

## Tests

Four added to `ConfigSubstitutionSharedTest`, each checked against the unfixed code:

| test | without the fix |
|---|---|
| `substitutionHiddenByObjectFromSubstitutionIsNotEvaluated` | **fails** — `UnresolvedSubstitution: ${y}` |
| `substitutionInsideObjectHiddenByNonObjectFromSubstitutionIsNotEvaluated` | **fails** — `UnresolvedSubstitution: ${does-not-exist}` |
| `substitutionInsideObjectHiddenByLiteralNonObjectIsNotEvaluated` | passes — the literal case already worked |
| `partiallyShadowedObjectWithInnerDelayedMergeResolves` | passes — guards the implementation, see above |

Upstream's `substitutionHiddenByLiteralNonObjectIsNotEvaluated` is not ported: `ignoreHiddenUndefinedSubst` already covers it. `objectDoesNotHideUndefinedSubst` (an object hiding a substitution *must* still evaluate it) still passes — that is the check against over-skipping.

Untested: the `NotResolved` fallback in `allKeysShadowed` (conservative, keeps pre-fix behaviour).

